### PR TITLE
Add option to set multiple species containing a specified string

### DIFF
--- a/aiida_fleur/tests/tools/test_xml_util.py
+++ b/aiida_fleur/tests/tools/test_xml_util.py
@@ -276,6 +276,26 @@ class TestSetSpecies:
         else:
             assert correct_result == result
 
+    @staticmethod
+    @pytest.mark.parametrize('attr_dict,correct_result,path', zip(attdicts, results, paths))
+    def test_set_species_all_string(inpxml_etree, attr_dict, correct_result, path):
+        from aiida_fleur.tools.xml_util import set_species, eval_xpath2
+        etree = inpxml_etree(TEST_INP_XML_PATH)
+
+        set_species(etree, 'all-Fe', attributedict=attr_dict)
+
+        result = eval_xpath2(etree, '/fleurInput/atomSpecies/species[@name="Fe-1"]/' + path)
+
+        if isinstance(correct_result, str):
+            if 'coreConfig' in path:
+                assert result[0].text == correct_result
+            else:
+                assert result[0] == correct_result
+        elif isinstance(correct_result, (float, int)):
+            assert result[0] == correct_result
+        else:
+            assert correct_result == result
+
     results_all = [[x, x] if not isinstance(x, list) else [x[0], x[1], x[0], x[1]] for x in results]
     @staticmethod
     @pytest.mark.parametrize('attr_dict,correct_result,path', zip(attdicts, results_all, paths))

--- a/aiida_fleur/tests/tools/test_xml_util.py
+++ b/aiida_fleur/tests/tools/test_xml_util.py
@@ -215,6 +215,7 @@ class TestSetSpecies:
              'electronConfig/stateOccupation/@state',
              'special/@socscale',
              'ldaU/@test_att',
+             'ldaU/@test_att',
              'lo/@test_att',
              'lo/@test_att'
              ]
@@ -228,13 +229,14 @@ class TestSetSpecies:
                                                         {'state': 'state2'}]}},
                 {'special': {'socscale': 1.0}},
                 {'ldaU': {'test_att': 2.0}},
+                {'ldaU': [{'test_att': 2.0}, {'test_att': 23.0}]},
                 {'lo': {'test_att': 2.0}},
                 {'lo': [{'test_att': 2.0}, {'test_att': 33.0}]}
                 #  'nocoParams': {'test_att' : 2, 'qss' : '123 123 123'},
                 ]
 
     results = ['3.333', '7.0', '3.0', 'test', 'state', [
-        'state', 'state2'], '1.0', '2.0', '2.0', ['2.0', '33.0']]
+        'state', 'state2'], '1.0', '2.0', ['2.0', '23.0'], '2.0', ['2.0', '33.0']]
 
     @staticmethod
     @pytest.mark.parametrize('attr_dict,correct_result,path', zip(attdicts, results, paths))

--- a/aiida_fleur/tools/xml_util.py
+++ b/aiida_fleur/tools/xml_util.py
@@ -789,6 +789,9 @@ def set_species(fleurinp_tree_copy, species_name, attributedict, create=False):
     # number, other parameters
     if species_name == 'all':
         xpath_species = '/fleurInput/atomSpecies/species'
+    elif 'all' in species_name: #format all-<string>
+        searchstr = species_name.split('-',maxsplit=1)[1]
+        xpath_species = '/fleurInput/atomSpecies/species[contains(@name,"{}")]'.format(searchstr)
     else:
         xpath_species = '/fleurInput/atomSpecies/species[@name = "{}"]'.format(species_name)
 

--- a/aiida_fleur/tools/xml_util.py
+++ b/aiida_fleur/tools/xml_util.py
@@ -789,9 +789,8 @@ def set_species(fleurinp_tree_copy, species_name, attributedict, create=False):
     # number, other parameters
     if species_name == 'all':
         xpath_species = '/fleurInput/atomSpecies/species'
-    elif 'all' in species_name: #format all-<string>
-        searchstr = species_name.split('-',maxsplit=1)[1]
-        xpath_species = '/fleurInput/atomSpecies/species[contains(@name,"{}")]'.format(searchstr)
+    elif 'all-' == species_name[:4]: #format all-<string>
+        xpath_species = '/fleurInput/atomSpecies/species[contains(@name,"{}")]'.format(species_name[4:])
     else:
         xpath_species = '/fleurInput/atomSpecies/species[@name = "{}"]'.format(species_name)
 

--- a/aiida_fleur/tools/xml_util.py
+++ b/aiida_fleur/tools/xml_util.py
@@ -913,8 +913,38 @@ def set_species(fleurinp_tree_copy, species_name, attributedict, create=False):
                             create=create,
                             tag_order=['coreConfig', 'valenceConfig', 'stateOccupation'])
         elif key == 'ldaU':
-            for attrib, value in six.iteritems(val):
-                xml_set_all_attribv(fleurinp_tree_copy, xpath_lda_u, attrib, value, create=True)
+            #Same policy as los: delete existing ldaU and add the ldaU specified
+            existingldaus = eval_xpath3(fleurinp_tree_copy, xpath_lda_u)
+            for ldau in existingldaus:
+                parent = ldau.getparent()
+                parent.remove(ldau)
+
+            if isinstance(val,dict):
+                create_tag(
+                    fleurinp_tree_copy,
+                    xpath_species,
+                    'ldaU',
+                    place_index=species_seq.index('ldaU'),
+                    tag_order=species_seq)
+                for attrib, value in six.iteritems(val):
+                    xml_set_all_attribv(fleurinp_tree_copy, xpath_lda_u, attrib, value, create=True)
+            else: #list of dicts
+
+                ldaus_needed = len(val)
+                for j in range(0, ldaus_needed):
+                    create_tag(
+                        fleurinp_tree_copy,
+                        xpath_species,
+                        'ldaU',
+                        place_index=species_seq.index('ldaU'),
+                        tag_order=species_seq)
+                for i, ldaudict in enumerate(val):
+                    for attrib, value in six.iteritems(ldaudict):
+                        sets = []
+                        for k in range(len(eval_xpath2(fleurinp_tree_copy, xpath_species + '/ldaU'))//ldaus_needed):
+                            sets.append(k * ldaus_needed + i)
+                        xml_set_attribv_occ(fleurinp_tree_copy, xpath_lda_u, attrib, value, occ=sets)
+
         elif key == 'special':
             eval_xpath3(fleurinp_tree_copy,
                         xpath_soc_scale,


### PR DESCRIPTION
```set_species``` now accepts ```species_name='all-<string>'``` as input and will apply changes to all species containing ```<string>``` in their name

See issue #87 