### PR TITLE
Add `python_requires` and relax `numpy` requirements

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -22,15 +22,16 @@
     ],
     "keywords": "fleur aiida inpgen workflows flapw juelich dft all-electron",
     "include_package_data": true,
+    "python_requires": ">=3.5",
     "setup_requires": [
         "reentry"
     ],
     "reentry_register": true,
     "install_requires": [
-        "aiida-core>=1.3.0,<2.0.0",
+        "aiida-core~=1.3",
         "lxml >= 3.6.4",
         "pytest-cov >= 2.5.0",
-        "numpy>=1.16.4,<1.20.0",
+        "numpy~=1.16,>=1.16.4",
         "sympy",
         "masci-tools>=0.3.12-dev4",
         "future",


### PR DESCRIPTION
Add the `python_requires` key to the `setup.json` which will inform
`pip` what minimum version of Python is supported. The upper requirement
of `numpy` is removed, since `pip` should automatically prevent
installing a version of `numpy` that requires a higher version of Python
than is installed.

Finally, the requirement for `aiida-core` is simplified by using the
compatibility operator `aiida-core~=1.3` which means exactly the same as
`aiida-core>=1.3,<2.0` but is more succinct and readable.