### PR TITLE
Fix CI and correct the `setup.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache python dependencies
       id: cache-pip
@@ -53,18 +53,17 @@ jobs:
           pip-pre-commit-
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 
     - name: Install python dependencies
-      run:
-        pip install git+https://github.com/aiidateam/aiida-testing@export_cache
+      run: |
         pip install .[pre-commit,testing]
         pip freeze
 
     - name: Run pre-commit
-      run: 
+      run:
         pre-commit run --all-files || (git status --short; git diff ; exit 1)
 
   tests:
@@ -74,10 +73,24 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.7', '3.6']
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_PASSWORD: ''
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+        - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+        - 5672:5672
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache python dependencies
       id: cache-pip
@@ -89,26 +102,18 @@ jobs:
           pip-${{ matrix.python-version }}-tests
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies
       run: |
-        wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-        echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
         sudo apt update
-        sudo apt install postgresql postgresql-server-dev-all postgresql-client
-        sudo apt install rabbitmq-server
-        sudo systemctl status rabbitmq-server.service
+        sudo apt install postgresql-10
 
     - name: Install python dependencies
       run: |
-        pip install numpy==1.16.4
-        pip install PyCifRW~=4.4
-        # install aiida-testing manually
-        #pip install git+https://github.com/broeder-j/aiida-testing.git@fa44c3ba4e57192fdbdee1cf3581576acc93800c
+        pip install --upgrade wheel setuptools
         pip install git+https://github.com/aiidateam/aiida-testing.git@export_cache
         pip install .[testing]
         reentry scan
@@ -118,9 +123,9 @@ jobs:
        # create fake codes for tests to work on ci
        cd ./tests/
        touch local_exe/inpgen && chmod +x local_exe/inpgen
-       touch local_exe/fleur && chmod +x local_exe/fleur 
+       touch local_exe/fleur && chmod +x local_exe/fleur
        ./run_all_cov.sh
-    
+
     - name: Upload report to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/aiida_fleur/tools/common_fleur_wf.py
+++ b/aiida_fleur/tools/common_fleur_wf.py
@@ -632,7 +632,7 @@ def find_last_submitted_calcjob(restart_wc):
     from aiida.common.exceptions import NotExistent
     from aiida.orm import CalcJobNode
     links = restart_wc.get_outgoing().all()
-    calls = list([x for x in links if isinstance(x.node, CalcJobNode)])
+    calls = [x for x in links if isinstance(x.node, CalcJobNode)]
     if calls:
         calls = sorted(calls, key=lambda x: x.node.pk)
         return calls[-1].node.uuid
@@ -648,7 +648,7 @@ def find_last_submitted_workchain(restart_wc):
     from aiida.common.exceptions import NotExistent
     from aiida.orm import WorkChainNode
     links = restart_wc.get_outgoing().all()
-    calls = list([x for x in links if isinstance(x.node, WorkChainNode)])
+    calls = [x for x in links if isinstance(x.node, WorkChainNode)]
     if calls:
         calls = sorted(calls, key=lambda x: x.node.pk)
         return calls[-1].node.uuid

--- a/aiida_fleur/workflows/create_magnetic_film.py
+++ b/aiida_fleur/workflows/create_magnetic_film.py
@@ -195,7 +195,7 @@ class FleurCreateMagneticWorkChain(WorkChain):
                         return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
 
         if 'relax' in inputs and 'distance_suggestion' not in inputs:
-            if 'eos' or 'eos_output' in inputs:
+            if 'eos' in inputs or 'eos_output' in inputs:
                 self.report('ERROR: relax wc input was given but distance_suggestion was not.')
                 return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
 

--- a/aiida_fleur/workflows/dmi.py
+++ b/aiida_fleur/workflows/dmi.py
@@ -528,7 +528,7 @@ class FleurDMIWorkChain(WorkChain):
                 for k in six.moves.range(i, i + num_ang - 1, 1):
                     t_energydict[k] -= ref_enrg
 
-            if e_u == 'Htr' or 'htr':
+            if e_u in ['Htr', 'htr']:
                 for labels, energies in t_energydict.items():
                     t_energydict[labels] = energies * HTR_TO_EV
         except AttributeError:

--- a/aiida_fleur/workflows/eos.py
+++ b/aiida_fleur/workflows/eos.py
@@ -220,7 +220,7 @@ class FleurEosWorkChain(WorkChain):
 
             t_e = outpara.get('total_energy', float('nan'))
             e_u = outpara.get('total_energy_units', 'eV')
-            if e_u == 'Htr' or 'htr':
+            if e_u in ['Htr', 'htr']:
                 t_e = t_e * HTR_TO_EV
             dis = outpara.get('distance_charge', float('nan'))
             dis_u = outpara.get('distance_charge_units', 'me/bohr^3')

--- a/aiida_fleur/workflows/mae.py
+++ b/aiida_fleur/workflows/mae.py
@@ -475,7 +475,7 @@ class FleurMaeWorkChain(WorkChain):
 
             minenergy = min(t_energydict)
 
-            if e_u == 'Htr' or 'htr':
+            if e_u in ['Htr', 'htr']:
                 t_energydict = [HTR_TO_EV * (x - minenergy) for x in t_energydict]
             else:
                 t_energydict = [(x - minenergy) for x in t_energydict]

--- a/aiida_fleur/workflows/mae_conv.py
+++ b/aiida_fleur/workflows/mae_conv.py
@@ -182,7 +182,7 @@ class FleurMaeConvWorkChain(WorkChain):
                 self.ctx.warnings.append(message)
                 continue
             e_u = outpara.get('total_energy_units', 'Htr')
-            if e_u == 'Htr' or 'htr':
+            if e_u in ['Htr', 'htr']:
                 t_e = t_e * HTR_TO_EV
             t_energydict[label] = t_e
 

--- a/aiida_fleur/workflows/ssdisp.py
+++ b/aiida_fleur/workflows/ssdisp.py
@@ -474,7 +474,7 @@ class FleurSSDispWorkChain(WorkChain):
             # Find a minimal value of SpSp and count it as 0
             minenergy = min(t_energydict)
 
-            if e_u == 'Htr' or 'htr':
+            if e_u in ['Htr', 'htr']:
                 t_energydict = [HTR_TO_EV * (x - minenergy) for x in t_energydict]
             else:
                 t_energydict = [(x - minenergy) for x in t_energydict]

--- a/aiida_fleur/workflows/ssdisp_conv.py
+++ b/aiida_fleur/workflows/ssdisp_conv.py
@@ -185,7 +185,7 @@ class FleurSSDispConvWorkChain(WorkChain):
                 self.ctx.warnings.append(message)
                 continue
             e_u = outpara.get('total_energy_units', 'Htr')
-            if e_u == 'Htr' or 'htr':
+            if e_u in ['Htr', 'htr']:
                 t_e = t_e * htr_to_eV
             t_energydict[label] = t_e
 

--- a/setup.json
+++ b/setup.json
@@ -12,9 +12,10 @@
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Environment :: Plugins",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Physics",
@@ -22,22 +23,20 @@
     ],
     "keywords": "fleur aiida inpgen workflows flapw juelich dft all-electron",
     "include_package_data": true,
+    "python_requires": ">=3.6",
     "setup_requires": [
         "reentry"
     ],
     "reentry_register": true,
     "install_requires": [
-        "aiida-core>=1.3.0,<2.0.0",
-        "lxml >= 3.6.4",
-        "pytest-cov >= 2.5.0",
-        "numpy>=1.16.4,<1.20.0",
+        "aiida-core[atomic_tools]>=1.3.0,<2.0.0",
+        "lxml>=3.6.4",
+        "numpy~=1.16,>=1.16.4",
         "sympy",
-        "masci-tools>=0.3.12-dev4",
+        "masci-tools>=0.3.12-dev4,<0.4.0",
         "future",
-        "ase",
-        "pymatgen",
         "pyhull",
-	"PyCifRW~=4.4"
+        "sqlalchemy<1.4"
     ],
     "extras_require": {
         "graphs ": [

--- a/tests/tools/test_common_aiida.py
+++ b/tests/tools/test_common_aiida.py
@@ -154,7 +154,7 @@ def test_get_nodes_from_group():
 
     w = get_nodes_from_group(group, return_format='uuid')
     assert len(w) == 3
-    assert all([isinstance(x, str) for x in w])
+    assert all(isinstance(x, str) for x in w)
 
     w = get_nodes_from_group(group, return_format='pk')
     assert len(w) == 3


### PR DESCRIPTION
Various fixes for the CI workflow

 * Update version of actions `checkout` and `setup-python` to v2
 * install Postgres and RabbitMQ through services. Note that we still
   need to install Postgres manually as well for `pgtest` to work.
 * Remove manual install of `numpy` which was a temporary workaround
   that is now obsolete.
 * Address the warnings from pylint
 * Fix the `pre-commit` job: multiline run statement did not use `|`
 * Add Python 3.9 to the tests matrix

Also the `setup.json` was

 * Remove compatibility for Python 3.5 from classifiers as it is EOL.
   The tests were also not being run for this version, as the dependency
   `aiida-testing` does not support it.
 * Add compatibility for Python 3.9 to classifiers
 * Add the `python_requires>=3.6` key
 * Install `aiida-core` with the `atomic_tools` extra. This allows to
   remove the explicit installs of `ase`, `pymatgen` and `PyCifRW`.
 * Add temporary upper limit on `sqlalchemy` which is a workaround for
   incompatibility with `sqlalchemy-utils`.
 * Add upper limit on `masci-tools` because of breaking changes.
 * Remove upper limit of `numpy` which is not necessary and causes
   conflicts with other packages for `aiida-common-workflows`.