### PR TITLE
Replace "getter" function internals in FleurinpData with new functions from `masci-tools`

### DIFF
--- a/aiida_fleur/calculation/fleur.py
+++ b/aiida_fleur/calculation/fleur.py
@@ -189,8 +189,6 @@ class FleurCalculation(CalcJob):
         'additional_retrieve_list', 'remove_from_retrieve_list', 'additional_remotecopy_list',
         'remove_from_remotecopy_list', 'cmdline'
     ]
-    # possible modes?
-    _fleur_modes = ['band', 'dos', 'forces', 'chargeDen', 'latticeCo', 'scf', 'force_theorem', 'gw', 'ldau']
 
     @classmethod
     def define(cls, spec):
@@ -403,7 +401,7 @@ class FleurCalculation(CalcJob):
                 mode_retrieved_filelist.append(self._DOS_FILE_NAME)
                 if with_hdf5:
                     mode_retrieved_filelist.append(self._BANDDOS_FILE_NAME)
-            if modes['forces']:
+            if modes['relax']:
                 # if l_f="T" retrieve relax.xml
                 mode_retrieved_filelist.append(self._RELAX_FILE_NAME)
             if modes['ldau']:

--- a/aiida_fleur/data/fleurinp.py
+++ b/aiida_fleur/data/fleurinp.py
@@ -415,8 +415,6 @@ class FleurinpData(Data):
         """
         return self.get_attribute('inp_version', None)
 
-    # TODO better validation? other files, if has a schema
-
     def _validate(self):
         """
         A validation method. Checks if an ``inp.xml`` file is in the FleurinpData.
@@ -433,39 +431,20 @@ class FleurinpData(Data):
                                   'FleurinpData needs to have and inp.xml file!')
 
     def get_fleur_modes(self):
-        '''
+        """
         Analyses ``inp.xml`` file to set up a calculation mode. 'Modes' are paths a FLEUR
-        calculation can take, resulting in different output files.
+        calculation can take, resulting in different output.
         This files can be automatically addded to the retrieve_list of the calculation.
 
         Common modes are: scf, jspin2, dos, band, pot8, lda+U, eels, ...
 
-        :return: a dictionary containing all possible modes. A mode is activated assigning a
-                 non-empty string to the corresponding key.
-        '''
-        # TODO these should be retrieved by looking at the inpfile structure and
-        # then setting the paths.
-        # use methods from fleur parser...
-        # For now they are hardcoded.
-        #    'dos': '/fleurInput/output',
-        #    'band': '/fleurInput/output',
-        #    'jspins': '/fleurInput/calculationSetup/magnetism',
-        fleur_modes = {'jspins': '', 'dos': '', 'band': '', 'ldau': '', 'forces': '', 'force_theorem': '', 'gw': ''}
-        if 'inp.xml' in self.files:
-            fleur_modes['jspins'] = self.inp_dict['calculationSetup']['magnetism']['jspins']
-            fleur_modes['dos'] = self.inp_dict['output']['dos']  # 'fleurInput']
-            fleur_modes['band'] = self.inp_dict['output']['band']
-            fleur_modes['forces'] = self.inp_dict['calculationSetup']['geometryOptimization']['l_f']
-            fleur_modes['force_theorem'] = 'forceTheorem' in self.inp_dict
-            try:
-                fleur_modes['gw'] = int(self.inp_dict['calculationSetup']['expertModes']['gw']) != 0
-            except KeyError:
-                fleur_modes['gw'] = False
-            fleur_modes['ldau'] = False
-            for species in self.inp_dict['atomSpecies']:
-                if 'ldaU' in species:
-                    fleur_modes['ldau'] = True
-        return fleur_modes
+        :return: a dictionary containing all possible modes.
+        """
+        from masci_tools.util.xml.xml_getters import get_fleur_modes
+
+        xmltree, schema_dict = self.load_inpxml()
+
+        return get_fleur_modes(xmltree, schema_dict)
 
     def get_nkpts(self):
         """
@@ -489,193 +468,17 @@ class FleurinpData(Data):
         :returns: StructureData node, or None
         """
         from aiida.orm import StructureData
-        from aiida_fleur.tools.StructureData_util import rel_to_abs, rel_to_abs_f
-        from masci_tools.io.parsers.fleur.fleur_schema import InputSchemaDict
+        from masci_tools.util.xml.xml_getters import get_structure_data
 
-        # StructureData = DataFactory(‘structure’)
-        # Disclaimer: this routine needs some xpath expressions. these are hardcoded here,
-        # therefore maintainance might be needed, if you want to circumvent this, you have
-        # to get all the paths from somewhere.
+        xmltree, schema_dict = self.load_inpxml()
 
-        #######
-        # all hardcoded xpaths used and attributes names:
-        bravaismatrix_bulk_xpath = '/fleurInput/cell/bulkLattice/bravaisMatrix/'
-        bravaismatrix_film_xpath = '/fleurInput/cell/filmLattice/bravaisMatrix/'
-        species_xpath = '/fleurInput/atomSpecies/species'
-        all_atom_groups_xpath = '/fleurInput/atomGroups/atomGroup'
+        atoms, cell, pbc = get_structure_data(xmltree, schema_dict)
 
-        species_attrib_name = 'name'
-        species_attrib_element = 'element'
+        struc = StructureData(cell=cell, pbc=pbc)
 
-        row1_tag_name = 'row-1'
-        row2_tag_name = 'row-2'
-        row3_tag_name = 'row-3'
+        for pos, symbol in atoms:
+            struc.append_atom(position=pos, symbols=symbol)
 
-        atom_group_attrib_species = 'species'
-        atom_group_tag_abspos = 'absPos'
-        atom_group_tag_relpos = 'relPos'
-        atom_group_tag_filmpos = 'filmPos'
-        ########
-
-        if 'inp.xml' not in self.files:
-            print('cannot get a StructureData because fleurinpdata has no inp.xml file yet')
-            # TODO what to do in this case?
-            return None
-
-        # read in inpxml
-
-        parser = etree.XMLParser(attribute_defaults=True, encoding='utf-8')
-        # dtd_validation=True
-        with self.open(path='inp.xml', mode='r') as inpxmlfile:
-            try:
-                tree = etree.parse(inpxmlfile, parser)
-            except etree.XMLSyntaxError as exc:
-                # prob inp.xml file broken
-                err_msg = ('The inp.xml file is probably broken, could not parse it to an xml etree.')
-                raise InputValidationError(err_msg) from exc
-
-        tree, _ = self._include_files(tree)
-
-        if self.inp_version is not None:
-            schema_dict = InputSchemaDict.fromVersion(self.inp_version)
-            if not schema_dict.xmlschema.validate(tree):
-                raise ValueError('Input file is not validated against the schema.')
-        else:
-            print('parsing inp.xml without XMLSchema')
-        root = tree.getroot()
-
-        # Fleur uses atomic units, convert to Angstrom
-        # get cell matrix from inp.xml
-        row1 = root.xpath(bravaismatrix_bulk_xpath + row1_tag_name)  # [0].text.split()
-        cell = None
-
-        if row1:  # bulk calculation
-            row1 = row1[0].text.split()
-            row2 = root.xpath(bravaismatrix_bulk_xpath + row2_tag_name)[0].text.split()
-            row3 = root.xpath(bravaismatrix_bulk_xpath + row3_tag_name)[0].text.split()
-            # TODO? allow math?
-            for i, cor in enumerate(row1):
-                row1[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row2):
-                row2[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row3):
-                row3[i] = float(cor) * BOHR_A
-
-            cell = [row1, row2, row3]
-            # create new structure Node
-            struc = StructureData(cell=cell)
-            struc.pbc = [True, True, True]
-
-        elif root.xpath(bravaismatrix_film_xpath + row1_tag_name):
-            # film calculation
-            row1 = root.xpath(bravaismatrix_film_xpath + row1_tag_name)[0].text.split()
-            row2 = root.xpath(bravaismatrix_film_xpath + row2_tag_name)[0].text.split()
-            row3 = root.xpath(bravaismatrix_film_xpath + row3_tag_name)[0].text.split()
-            for i, cor in enumerate(row1):
-                row1[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row2):
-                row2[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row3):
-                row3[i] = float(cor) * BOHR_A
-            # row3 = [0, 0, 0]#? TODO:what has it to be in this case?
-            cell = [row1, row2, row3]
-            struc = StructureData(cell=cell)
-            struc.pbc = [True, True, False]
-
-        if cell is None:
-            print('Could not extract Bravias matrix out of inp.xml. Is the '
-                  'Bravias matrix explicitly given? i.e Latnam definition '
-                  'not supported.')
-            return None
-
-        # get species for atom kinds
-        #species = root.xpath(species_xpath)
-        species_name = root.xpath(species_xpath + '/@' + species_attrib_name)
-        species_element = root.xpath(species_xpath + '/@' + species_attrib_element)
-        # alternativ: loop over species and species.get(species_attrib_name)
-
-        # save species info in a dict
-        species_dict = {}
-        for i, spec in enumerate(species_name):
-            species_dict[spec] = {species_attrib_element: species_element[i]}
-
-        # Now we have to get all atomgroups, look what their species is and
-        # their positions are.
-        # Then we append them to the new structureData
-
-        all_atom_groups = root.xpath(all_atom_groups_xpath)
-
-        for atom_group in all_atom_groups:
-            current_species = atom_group.get(atom_group_attrib_species)
-
-            group_atom_positions_abs = atom_group.xpath(atom_group_tag_abspos)
-            group_atom_positions_rel = atom_group.xpath(atom_group_tag_relpos)
-            group_atom_positions_film = atom_group.xpath(atom_group_tag_filmpos)
-
-            if group_atom_positions_abs:  # we have absolute positions
-                for atom in group_atom_positions_abs:
-                    postion_a = atom.text.split()
-                    # allow for math *, /
-                    for i, pos in enumerate(postion_a):
-                        if '/' in pos:
-                            temppos = pos.split('/')
-                            postion_a[i] = float(temppos[0]) / float(temppos[1])
-                        elif '*' in pos:
-                            temppos = pos.split('*')
-                            postion_a[i] = float(temppos[0]) * float(temppos[1])
-                        else:
-                            postion_a[i] = float(pos)
-                        postion_a[i] = postion_a[i] * BOHR_A
-                    # append atom to StructureData
-                    struc.append_atom(position=postion_a, symbols=species_dict[current_species][species_attrib_element])
-
-            elif group_atom_positions_rel:  # we have relative positions
-                # TODO: check if film or 1D calc, because this is not allowed! I guess
-                for atom in group_atom_positions_rel:
-                    postion_r = atom.text.split()
-                    # allow for math * /
-                    for i, pos in enumerate(postion_r):
-                        if '/' in pos:
-                            temppos = pos.split('/')
-                            postion_r[i] = float(temppos[0]) / float(temppos[1])
-                        elif '*' in pos:
-                            temppos = pos.split('*')
-                            postion_r[i] = float(temppos[0]) * float(temppos[1])
-                        else:
-                            postion_r[i] = float(pos)
-
-                    # now transform to absolute Positions
-                    new_abs_pos = rel_to_abs(postion_r, cell)
-
-                    # append atom to StructureData
-                    struc.append_atom(position=new_abs_pos,
-                                      symbols=species_dict[current_species][species_attrib_element])
-
-            elif group_atom_positions_film:  # Do we support mixture always, or only in film case?
-                # either support or throw error
-                for atom in group_atom_positions_film:
-                    # film pos are rel rel abs, therefore only transform first two coordinates
-                    postion_f = atom.text.split()
-                    # allow for math * /
-                    for i, pos in enumerate(postion_f):
-                        if '/' in pos:
-                            temppos = pos.split('/')
-                            postion_f[i] = float(temppos[0]) / float(temppos[1])
-                        elif '*' in postion_f[i]:
-                            temppos = pos.split('*')
-                            postion_f[i] = float(temppos[0]) * float(temppos[1])
-                        else:
-                            postion_f[i] = float(pos)
-                    # now transform to absolute Positions
-                    postion_f[2] = postion_f[2] * BOHR_A
-                    new_abs_pos = rel_to_abs_f(postion_f, cell)
-                    # append atom to StructureData
-                    struc.append_atom(position=new_abs_pos,
-                                      symbols=species_dict[current_species][species_attrib_element])
-            else:
-                # TODO throw error
-                print('I should never get here, 1D not supported yet, ' 'I only know relPos, absPos, filmPos')
-                # TODO throw error
         # TODO DATA-DATA links are not wanted, you might want to use a cf instead
         #struc.add_link_from(self, label='self.structure', link_type=LinkType.CREATE)
         # label='self.structure'
@@ -694,7 +497,7 @@ class FleurinpData(Data):
         """
         return self.get_structuredata_ncf()
 
-    def get_kpointsdata_ncf(self, index=0):
+    def get_kpointsdata_ncf(self, name=None):
         """
         This routine returns an AiiDA :class:`~aiida.orm.KpointsData` type produced from the
         ``inp.xml`` file. This only works if the kpoints are listed in the in inpxml.
@@ -703,7 +506,7 @@ class FleurinpData(Data):
         :returns: :class:`~aiida.orm.KpointsData` node
         """
         from aiida.orm import KpointsData
-        from masci_tools.io.parsers.fleur.fleur_schema import InputSchemaDict
+        from masci_tools.util.xml.xml_getters import get_kpoints_data
 
         # HINT, TODO:? in this routine, the 'cell' you might get in an other way
         # exp: StructureData.cell, but for this you have to make a structureData Node,
@@ -716,145 +519,35 @@ class FleurinpData(Data):
         # if you want to circumvent this, you have
         # to get all the paths from somewhere.
 
-        #######
-        # all hardcoded xpaths used and attributes names:
-        bravaismatrix_bulk_xpath = '/fleurInput/cell/bulkLattice/bravaisMatrix/'
-        bravaismatrix_film_xpath = '/fleurInput/cell/filmLattice/bravaisMatrix/'
-        #kpointlist_xpath = '/fleurInput/calculationSetup/bzIntegration//kPointList/'
-        #kpointlist_xpath = '/fleurInput/cell/bzIntegration/kPointLists/kPointList'
-        kpointlist_xpath = '/fleurInput//kPointList'
-        kpoint_tag = 'kPoint'
-        kpointlist_attrib_posscale = 'posScale'
-        kpointlist_attrib_weightscale = 'weightScale'
-        #kpointlist_attrib_count = 'count'
-        kpoint_attrib_weight = 'weight'
-        row1_tag_name = 'row-1'
-        row2_tag_name = 'row-2'
-        row3_tag_name = 'row-3'
-        ########
+        xmltree, schema_dict = self.load_inpxml()
 
-        if 'inp.xml' not in self.files:
-            print('cannot get a KpointsData because fleurinpdata has no inp.xml file yet')
-            # TODO what to do in this case?
-            return False
-
-        # else read in inpxml
-
-        parser = etree.XMLParser(attribute_defaults=True, encoding='utf-8')
-        # dtd_validation=True
-        with self.open(path='inp.xml', mode='r') as inpxmlfile:
-            try:
-                tree = etree.parse(inpxmlfile, parser)
-            except etree.XMLSyntaxError as exc:
-                # prob inp.xml file broken
-                err_msg = ('The inp.xml file is probably broken, could not parse it to an xml etree.')
-                raise InputValidationError(err_msg) from exc
-
-        tree, _ = self._include_files(tree)
-
-        if self.inp_version is not None:
-            schema_dict = InputSchemaDict.fromVersion(self.inp_version)
-            if not schema_dict.xmlschema.validate(tree):
-                raise ValueError('Input file is not validated against the schema.')
+        if name is None:
+            kpoints, weights, cell, pbc = get_kpoints_data(xmltree, schema_dict)
         else:
-            print('parsing inp.xml without XMLSchema')
+            kpoints, weights, cell, pbc = get_kpoints_data(xmltree, schema_dict, name=name)
 
-        root = tree.getroot()
+        if isinstance(kpoints, dict):
+            kpoints_data = {}
+            for (label, kpoints_set), weights_set in zip(kpoints.items(), weights.values()):
+                kps = KpointsData()
+                kps.set_cell(cell)
+                kps.pbc = pbc
+                kps.set_kpoints(kpoints_set, cartesian=False, weights=weights_set)
+                #kpoints_data.add_link_from(self, label='fleurinp.kpts', link_type=LinkType.CREATE)
+                kps.label = 'fleurinp.kpts'
+                kpoints_data[label] = kps
+        else:
+            kpoints_data = KpointsData()
+            kpoints_data.set_cell(cell)
+            kpoints_data.pbc = pbc
+            kpoints_data.set_kpoints(kpoints, cartesian=False, weights=weights)
+            #kpoints_data.add_link_from(self, label='fleurinp.kpts', link_type=LinkType.CREATE)
+            kpoints_data.label = 'fleurinp.kpts'
 
-        # get cell matrix from inp.xml
-        cell = None
-        row1 = root.xpath(bravaismatrix_bulk_xpath + row1_tag_name)  # [0].text.split()
-
-        if row1:  # bulk calculation
-            row1 = row1[0].text.split()
-            row2 = root.xpath(bravaismatrix_bulk_xpath + row2_tag_name)[0].text.split()
-            row3 = root.xpath(bravaismatrix_bulk_xpath + row3_tag_name)[0].text.split()
-            # TODO? allow math?
-            for i, cor in enumerate(row1):
-                row1[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row2):
-                row2[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row3):
-                row3[i] = float(cor) * BOHR_A
-
-            cell = [row1, row2, row3]
-            # set boundary conditions
-            pbc1 = [True, True, True]
-
-        elif root.xpath(bravaismatrix_film_xpath + row1_tag_name):
-            # film calculation
-            row1 = root.xpath(bravaismatrix_film_xpath + row1_tag_name)[0].text.split()
-            row2 = root.xpath(bravaismatrix_film_xpath + row2_tag_name)[0].text.split()
-            row3 = root.xpath(bravaismatrix_film_xpath + row3_tag_name)[0].text.split()
-            for i, cor in enumerate(row1):
-                row1[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row2):
-                row2[i] = float(cor) * BOHR_A
-            for i, cor in enumerate(row3):
-                row3[i] = float(cor) * BOHR_A
-            # row3 = [0, 0, 0]#? TODO:what has it to be in this case?
-            cell = [row1, row2, row3]
-            pbc1 = [True, True, False]
-
-        if cell is None:
-            print('Could not extract Bravias matrix out of inp.xml. Is the '
-                  'Bravias matrix explicitly given? i.e Latnam definition '
-                  'not supported.')
-            return None
-        # get kpoints only works if kpointlist in inp.xml
-        kpointslists = root.xpath(kpointlist_xpath)  # + kpoint_tag)
-
-        if kpointslists:
-            # TODO in fleur there can be several sets, either return the one which is meant to be calculated,
-            # or return all
-            index = int(index)
-            if len(kpointslists) != 1:
-                print('Found {} kpoints lists in the inp.xml file, the one with index {} will be returned only.'.format(
-                    len(kpointslists), index))
-
-            kpoints = kpointslists[index].xpath(kpoint_tag)
-            #posscale = root.xpath(kpointlist_xpath + '@' + kpointlist_attrib_posscale)
-            posscale = kpointslists[index].xpath('@' + kpointlist_attrib_posscale)
-            if not posscale:
-                posscale = [1.0]
-            #weightscale = root.xpath(kpointlist_xpath + '@' + kpointlist_attrib_weightscale)
-            weightscale = kpointslists[index].xpath('@' + kpointlist_attrib_weightscale)
-            if not weightscale:
-                weightscale = [1.0]
-            #count = root.xpath(kpointlist_xpath + '@' + kpointlist_attrib_count)
-
-            kpoints_pos = []
-            kpoints_weight = []
-
-            for kpoint in kpoints:
-                kpoint_pos = kpoint.text.split()
-                for i, kval in enumerate(kpoint_pos):
-                    if isinstance(kval, str):
-                        if '/' in kval:
-                            parts = kval.split('/')
-                            kval = float(parts[0]) / float(parts[1])
-                    kpoint_pos[i] = float(kval) / float(posscale[0])
-                    kpoint_weight = float(kpoint.get(kpoint_attrib_weight)) / float(weightscale[0])
-                kpoints_pos.append(kpoint_pos)
-                kpoints_weight.append(kpoint_weight)
-            totalw = 0
-            for weight in kpoints_weight:
-                totalw = totalw + weight
-            kps = KpointsData()
-            kps.set_cell(cell)
-            kps.pbc = pbc1
-
-            kps.set_kpoints(kpoints_pos, cartesian=False, weights=kpoints_weight)
-            #kps.add_link_from(self, label='fleurinp.kpts', link_type=LinkType.CREATE)
-            kps.label = 'fleurinp.kpts'
-            # return {label: kps}
-            return kps
-        else:  # TODO parser other kpoints formats, if they fit in an AiiDA node
-            print('No kpoint list in inp.xml')
-            return None
+        return kpoints_data
 
     @cf
-    def get_kpointsdata(self, index=None):
+    def get_kpointsdata(self, name=None):
         """
         This routine returns an AiiDA :class:`~aiida.orm.KpointsData` type produced from the
         ``inp.xml`` file. This only works if the kpoints are listed in the in inpxml.
@@ -862,9 +555,7 @@ class FleurinpData(Data):
 
         :returns: :class:`~aiida.orm.KpointsData` node
         """
-        if index is None:
-            index = Int(0)
-        return self.get_kpointsdata_ncf(index=index)
+        return self.get_kpointsdata_ncf(name=name)
 
     def get_parameterdata_ncf(self, inpgen_ready=True, write_ids=True):
         """
@@ -874,21 +565,14 @@ class FleurinpData(Data):
 
         :returns: :class:`~aiida.orm.Dict` node
         """
-        from aiida_fleur.tools.xml_util import get_inpgen_paranode_from_xml
-        from masci_tools.io.parsers.fleur.fleur_schema import InputSchemaDict
-        if 'inp.xml' not in self.files:
-            print('cannot get a StructureData because fleurinpdata has no inp.xml file yet')
-            # TODO what to do in this case?
-            return False
+        from aiida.orm import Dict
+        from masci_tools.util.xml.xml_getters import get_parameter_data
 
-        schema_dict = InputSchemaDict.fromVersion(self.inp_version)
-        # read in inpxml
-        with self.open(path='inp.xml', mode='r') as inpxmlfile:
-            new_parameters = get_inpgen_paranode_from_xml(etree.parse(inpxmlfile),
-                                                          schema_dict,
-                                                          inpgen_ready=inpgen_ready,
-                                                          write_ids=write_ids)
-        return new_parameters
+        xmltree, schema_dict = self.load_inpxml()
+
+        parameter_data = get_parameter_data(xmltree, schema_dict, inpgen_ready=inpgen_ready, write_ids=write_ids)
+
+        return Dict(dict=parameter_data)
 
     @cf
     def get_parameterdata(self):

--- a/aiida_fleur/data/fleurinp.py
+++ b/aiida_fleur/data/fleurinp.py
@@ -30,12 +30,9 @@ import six
 from lxml import etree
 import warnings
 
-from aiida.orm import Data, Node, load_node, Int
+from aiida.orm import Data, Node, load_node
 from aiida.common.exceptions import InputValidationError, ValidationError
 from aiida.engine.processes.functions import calcfunction as cf
-
-from aiida_fleur.tools.xml_util import replace_tag
-from aiida_fleur.common.constants import BOHR_A
 
 
 class FleurinpData(Data):
@@ -497,11 +494,16 @@ class FleurinpData(Data):
         """
         return self.get_structuredata_ncf()
 
-    def get_kpointsdata_ncf(self, name=None):
+    def get_kpointsdata_ncf(self, name=None, index=None):
         """
         This routine returns an AiiDA :class:`~aiida.orm.KpointsData` type produced from the
         ``inp.xml`` file. This only works if the kpoints are listed in the in inpxml.
         This is NOT a calcfunction and does not keep the provenance!
+
+        :param name: str, optional, if given only the kpoint set with the given name
+                     is returned
+        :param index: int, optional, if given only the kpoint set with the given index
+                      is returned
 
         :returns: :class:`~aiida.orm.KpointsData` node
         """
@@ -514,17 +516,12 @@ class FleurinpData(Data):
         # then just parsing the cell from the inp.xml
         # as in the routine get_structureData
 
-        # Disclaimer: this routine needs some xpath expressions.
-        # these are hardcoded here, therefore maintainance might be needed,
-        # if you want to circumvent this, you have
-        # to get all the paths from somewhere.
-
         xmltree, schema_dict = self.load_inpxml()
 
-        if name is None:
+        if name is None and index is None:
             kpoints, weights, cell, pbc = get_kpoints_data(xmltree, schema_dict)
         else:
-            kpoints, weights, cell, pbc = get_kpoints_data(xmltree, schema_dict, name=name)
+            kpoints, weights, cell, pbc = get_kpoints_data(xmltree, schema_dict, name=name, index=index)
 
         if isinstance(kpoints, dict):
             kpoints_data = {}
@@ -547,7 +544,7 @@ class FleurinpData(Data):
         return kpoints_data
 
     @cf
-    def get_kpointsdata(self, name=None):
+    def get_kpointsdata(self, name=None, index=None):
         """
         This routine returns an AiiDA :class:`~aiida.orm.KpointsData` type produced from the
         ``inp.xml`` file. This only works if the kpoints are listed in the in inpxml.
@@ -555,7 +552,7 @@ class FleurinpData(Data):
 
         :returns: :class:`~aiida.orm.KpointsData` node
         """
-        return self.get_kpointsdata_ncf(name=name)
+        return self.get_kpointsdata_ncf(name=name, index=index)
 
     def get_parameterdata_ncf(self, inpgen_ready=True, write_ids=True):
         """

--- a/aiida_fleur/data/fleurinp.py
+++ b/aiida_fleur/data/fleurinp.py
@@ -96,14 +96,14 @@ class FleurinpData(Data):
                 self.set_files(files)
 
     @property
-    def _parser_info(self):
+    def parser_info(self):
         """
         Dict property, with the info and warnings from the inpxml_parser
         """
         return self.get_extra('_parser_info')
 
-    @_parser_info.setter
-    def _parser_info(self, info_dict):
+    @parser_info.setter
+    def parser_info(self, info_dict):
         """
         Setter for has_schema
         """
@@ -314,7 +314,7 @@ class FleurinpData(Data):
         except (ValueError, FileNotFoundError) as exc:
             raise InputValidationError from exc
 
-        self._parser_info = parser_info
+        self.parser_info = parser_info
         # set inpxml_dict attribute
         self.set_attribute('inp_dict', inpxml_dict)
 

--- a/docs/source/user_guide/data/fleurinp_data.rst
+++ b/docs/source/user_guide/data/fleurinp_data.rst
@@ -81,10 +81,10 @@ Properties
 
     * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_version`: Returns the version of the stored ``inp.xml``
 
-    * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.parser_info`: Returns errors, warnings and information encountered while constructung the :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_dict` from the ``inp.xml``
+    * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.parser_info`: Returns errors, warnings and information encountered while constructing the :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_dict` from the ``inp.xml``
 
 .. note::
-  :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` will use the ``masci-tools`` library to parse the ``inp.xml``. This library contains the schema files for the fleur input and output XML files for many of the fleur releases starting from version ``0.27``. If a version is encountered that is not yet stored in the ``masci-tools`` library, the latest available version is used.
+  :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` will use the ``masci-tools`` library to parse the ``inp.xml``. This library contains the schema files for the fleur input and output XML files for many of the fleur releases starting from version ``0.27``. If a version is encountered that is not yet stored in the installed version of the ``masci-tools`` library, the latest available version is used.
 
 User Methods
 ------------

--- a/docs/source/user_guide/data/fleurinp_data.rst
+++ b/docs/source/user_guide/data/fleurinp_data.rst
@@ -81,7 +81,7 @@ Properties
 
     * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_version`: Returns the version of the stored ``inp.xml``
 
-    * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData._parser_info`: Returns errors, warnings and information encountered while constructung the :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_dict` from the ``inp.xml``
+    * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.parser_info`: Returns errors, warnings and information encountered while constructung the :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_dict` from the ``inp.xml``
 
 .. note::
   :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` will use the ``masci-tools`` library to parse the ``inp.xml``. This library contains the schema files for the fleur input and output XML files for many of the fleur releases starting from version ``0.27``. If a version is encountered that is not yet stored in the ``masci-tools`` library, the latest available version is used.

--- a/docs/source/user_guide/data/fleurinp_data.rst
+++ b/docs/source/user_guide/data/fleurinp_data.rst
@@ -79,16 +79,12 @@ Properties
       which were added to FleurinpData. Note that all of these
       files will be copied to the folder where FLEUR will be run.
 
-    .. * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData._schema_file_path`: Returns the absolute
-    ..   path of the xml schema file used for the current inp.xml file.
+    * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_version`: Returns the version of the stored ``inp.xml``
+
+    * :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData._parser_info`: Returns errors, warnings and information encountered while constructung the :py:exc:`~aiida_fleur.data.fleurinp.FleurinpData.inp_dict` from the ``inp.xml``
 
 .. note::
-  :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` will first look in the ``aiida_fleur/fleur_schema/input/`` for matching Fleur
-  xml schema files to the ``inp.xml`` files.
-  If it does not find a match there, it will recursively search in your PYTHONPATH
-  and the current directory.
-  If you installed the package with pip there should be no problem, as long the package versions
-  is new enough for the version of the Fleur code you are deploying.
+  :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` will use the ``masci-tools`` library to parse the ``inp.xml``. This library contains the schema files for the fleur input and output XML files for many of the fleur releases starting from version ``0.27``. If a version is encountered that is not yet stored in the ``masci-tools`` library, the latest available version is used.
 
 User Methods
 ------------
@@ -99,14 +95,14 @@ User Methods
       to :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` instance.
     * :py:func:`~aiida_fleur.data.fleurinp.FleurinpData.set_files()` - Adds several files from a
       folder node to :py:class:`~aiida_fleur.data.fleurinp.FleurinpData` instance.
-    * :py:func:`~aiida_fleur.data.fleurinp.FleurinpData.get_fleur_modes()` - Analyses inp.xml and
-      get a corresponding calculation mode.
+    * :py:func:`~aiida_fleur.data.fleurinp.FleurinpData.get_fleur_modes()` - Analyses the inp.xml and
+      get a  dictionary with the corresponding calculation modes (Noco, SOC, ...)
     * :py:func:`~aiida_fleur.data.fleurinp.FleurinpData.get_structuredata()` - A CalcFunction which
       returns an AiiDA :py:class:`~aiida.orm.StructureData`
       type extracted from the inp.xml file.
     * :py:func:`~aiida_fleur.data.fleurinp.FleurinpData.get_kpointsdata()` - A CalcFunction which
       returns an AiiDA :py:class:`~aiida.orm.KpointsData`
-      type produced from the inp.xml
+      type produced from the inp.xml. If multiple k-point sets are defined (Fleur release MaX5 or later) a dictionary of :py:class:`~aiida.orm.KpointsData` types is returned
       file. This only works if the kpoints are listed in the in inp.xml.
     * :py:func:`~aiida_fleur.data.fleurinp.FleurinpData.get_parameterdata()` - A CalcFunction
       that extracts a :py:class:`~aiida.orm.Dict` node

--- a/setup.json
+++ b/setup.json
@@ -33,7 +33,7 @@
         "lxml>=3.6.4",
         "numpy~=1.16,>=1.16.4",
         "sympy",
-        "masci-tools>=0.4.7",
+        "masci-tools >= 0.4.8.dev2,<0.5.0",
         "future",
         "pyhull",
         "sqlalchemy<1.4"

--- a/tests/data/test_fleurinp.py
+++ b/tests/data/test_fleurinp.py
@@ -78,7 +78,10 @@ def test_fleurinp_kpointsdata_extraction(create_fleurinp, inpxmlfilepath):
     kptsd = fleurinp_tmp.get_kpointsdata_ncf()
 
     if kptsd is not None:
-        assert isinstance(kptsd, KpointsData)
+        assert isinstance(kptsd, (KpointsData, dict))
+
+        if isinstance(kptsd, dict):
+            assert all(isinstance(val, KpointsData) for val in kptsd.values())
     else:
         pass
         # What todo here, may test inpxml are with latnam definded, which does not work here.

--- a/tests/data/test_fleurinp.py
+++ b/tests/data/test_fleurinp.py
@@ -51,7 +51,7 @@ def test_fleurinp_valid_inpxml(create_fleurinp, inpxmlfilepath):
     fleurinp_tmp = create_fleurinp(inpxmlfilepath)
 
     assert fleurinp_tmp.inp_dict != {}
-    assert fleurinp_tmp._parser_info['parser_warnings'] == []
+    assert fleurinp_tmp.parser_info['parser_warnings'] == []
     assert fleurinp_tmp._validate() is None  # if fails, _validate throws an error
 
 

--- a/tests/data/test_fleurinp.py
+++ b/tests/data/test_fleurinp.py
@@ -36,6 +36,12 @@ for subdir, dirs, files in os.walk(inpxmlfilefolder_non_valid):
         if file.endswith('.xml'):
             inpxmlfilelist2.append(os.path.join(subdir, file))
 
+INPXML_LATNAM_DEFINITION = [
+    'Fe_bct_SOCXML', 'CuBulkXML', 'CuBandXML', 'Bi2Te3XML', 'PTO-SOCXML', 'Fe_bctXML', 'Fe_1lXML', 'Fe_1l_SOCXML',
+    'Fe_bct_LOXML', 'NiO_ldauXML', 'CuDOSXML', 'PTOXML'
+]
+INPXML_NO_KPOINTLISTS = ['GaAsMultiForceXML']
+
 
 @pytest.mark.parametrize('inpxmlfilepath', inpxmlfilelist)
 def test_fleurinp_valid_inpxml(create_fleurinp, inpxmlfilepath):
@@ -75,17 +81,20 @@ def test_fleurinp_kpointsdata_extraction(create_fleurinp, inpxmlfilepath):
     from aiida.orm import KpointsData
 
     fleurinp_tmp = create_fleurinp(inpxmlfilepath)
-    kptsd = fleurinp_tmp.get_kpointsdata_ncf()
 
-    if kptsd is not None:
+    if any(folder in inpxmlfilepath for folder in INPXML_LATNAM_DEFINITION):
+        with pytest.raises(ValueError, match='Could not extract Bravais matrix out of inp.xml.'):
+            fleurinp_tmp.get_kpointsdata_ncf()
+    elif any(folder in inpxmlfilepath for folder in INPXML_NO_KPOINTLISTS):
+        with pytest.raises(ValueError, match='No Kpoint lists found in the given inp.xml'):
+            fleurinp_tmp.get_kpointsdata_ncf()
+    else:
+        kptsd = fleurinp_tmp.get_kpointsdata_ncf()
+
         assert isinstance(kptsd, (KpointsData, dict))
 
         if isinstance(kptsd, dict):
             assert all(isinstance(val, KpointsData) for val in kptsd.values())
-    else:
-        pass
-        # What todo here, may test inpxml are with latnam definded, which does not work here.
-        # or without a kpoint list. Therefore this test might let two much through
 
 
 @pytest.mark.parametrize('inpxmlfilepath', inpxmlfilelist)
@@ -113,12 +122,14 @@ def test_fleurinp_structuredata_extraction(create_fleurinp, inpxmlfilepath):
     from aiida.orm import StructureData
 
     fleurinp_tmp = create_fleurinp(inpxmlfilepath)
-    struc = fleurinp_tmp.get_structuredata_ncf()
-
-    if struc is not None:
-        assert isinstance(struc, StructureData)
+    if any(folder in inpxmlfilepath for folder in INPXML_LATNAM_DEFINITION):
+        with pytest.raises(ValueError, match='Could not extract Bravais matrix out of inp.xml.'):
+            fleurinp_tmp.get_structuredata_ncf()
     else:
-        pass
+        struc = fleurinp_tmp.get_structuredata_ncf()
+
+        assert isinstance(struc, StructureData)
+
     #    # What todo here, may test inpxml are with latnam definded,
     #    # which does not work here.
     #    # But if something else fails also None return. T


### PR DESCRIPTION
This PR replaces the content of the following methods of the `FleurinpData` (namely the XML parsing parts) with their new implementations in the `masci-tools` library:

- get_parameter_data
- get_kpoints_data
- get_structure_data

and their `_ncf` counterparts

`get_kpoints_data` can now naturally handle multiple point sets for versions after Max5 and returns them in a dictionary. Selection for these is based on the name of the Kpointset

TODO:
- [x] Some Tests for these methods fail (kpoints and structure), since the old functions did not raise errors strictly (for e.g. latnam definition of the bravais matrix)