### PR TITLE
Remove/Deprecate explicit xpath usage

### DIFF
--- a/aiida_fleur/tools/extract_corelevels.py
+++ b/aiida_fleur/tools/extract_corelevels.py
@@ -113,9 +113,10 @@ def extract_corelevels(outxmlfile, options=None):
     #######################################
     ########################
     #XPATHS to maintain
-    warnings.warn('extract_corelevels is deprecated. You can use the outxml_parser\n'
-                  "in masci_tools.io.parsers.fleur instead with outxml_parser(outxmlfile, optional_tasks=('corelevels'))\n"
-                  'To get this information', DeprecationWarning)
+    warnings.warn(
+        'extract_corelevels is deprecated. You can use the outxml_parser\n'
+        "in masci_tools.io.parsers.fleur instead with outxml_parser(outxmlfile, optional_tasks=('corelevels'))\n"
+        'To get this information', DeprecationWarning)
 
     species_xpath = '/fleurOutput/inputData/atomSpecies'
     iteration_xpath = '/fleurOutput/scfLoop/iteration'

--- a/aiida_fleur/tools/extract_corelevels.py
+++ b/aiida_fleur/tools/extract_corelevels.py
@@ -17,6 +17,7 @@ out.xml file of FLEUR.
 # TODO together with xml_util, parser info handling, has to be also a return value of everything
 # or rather throw exception on lowest level and catch at higher levels?
 from lxml import etree  #, objectify
+import warnings
 
 from masci_tools.util.xml.common_functions import eval_xpath, get_xml_attribute
 #convert_to_float
@@ -112,6 +113,9 @@ def extract_corelevels(outxmlfile, options=None):
     #######################################
     ########################
     #XPATHS to maintain
+    warnings.warn('extract_corelevels is deprecated. You can use the outxml_parser\n'
+                  "in masci_tools.io.parsers.fleur instead with outxml_parser(outxmlfile, optional_tasks=('corelevels'))\n"
+                  'To get this information', DeprecationWarning)
 
     species_xpath = '/fleurOutput/inputData/atomSpecies'
     iteration_xpath = '/fleurOutput/scfLoop/iteration'

--- a/aiida_fleur/tools/io_routines.py
+++ b/aiida_fleur/tools/io_routines.py
@@ -146,7 +146,7 @@ def compress_fleuroutxml(outxmlfilepath, dest_file_path=None, delete_eig=True, i
             position_keep = n_iters + iterations_to_keep + 1
             delete_xpath = f'{xpath_iteration}[position()<{int(position_keep)}]'
         else:
-            delete_xpath = f'{xpath_iteration}[position()<{int(iterations_to_keep)}]'
+            delete_xpath = f'{xpath_iteration}[position()>{int(iterations_to_keep)}]'
 
         if abs(iterations_to_keep) > n_iters:
             warnings.warn('iterations_to_keep is larger then the number of iterations'

--- a/aiida_fleur/tools/io_routines.py
+++ b/aiida_fleur/tools/io_routines.py
@@ -15,6 +15,7 @@ For example collection of data or database evaluations, for other people.
 """
 import warnings
 
+
 def write_results_to_file(headerstring, data, destination='./outputfile', seperator='  ', transpose=True):
     """
     Writes data to a file
@@ -149,13 +150,14 @@ def compress_fleuroutxml(outxmlfilepath, dest_file_path=None, delete_eig=True, i
             delete_xpath = f'{xpath_iteration}[position()>{int(iterations_to_keep)}]'
 
         if abs(iterations_to_keep) > n_iters:
-            warnings.warn('iterations_to_keep is larger then the number of iterations'
-                  ' in the given out.xml file, I keep all.', UserWarning)
+            warnings.warn(
+                'iterations_to_keep is larger then the number of iterations'
+                ' in the given out.xml file, I keep all.', UserWarning)
         else:
             print(f'Deleting iterations under the xpath: {delete_xpath}')
-            xmltree = delete_tag(xmltree,schema_dict, 'iteration', complex_xpath=delete_xpath)
+            xmltree = delete_tag(xmltree, schema_dict, 'iteration', complex_xpath=delete_xpath)
 
-    etree.indent(xmltree) #Make sure the print looks nice
+    etree.indent(xmltree)  #Make sure the print looks nice
 
     if dest_file_path is None:
         dest_file_path = outxmlfilepath  # overwrite file

--- a/aiida_fleur/tools/io_routines.py
+++ b/aiida_fleur/tools/io_routines.py
@@ -13,7 +13,7 @@
 Here we collect IO routines and their utility, for writting certain things to files, or post process files.
 For example collection of data or database evaluations, for other people.
 """
-
+import warnings
 
 def write_results_to_file(headerstring, data, destination='./outputfile', seperator='  ', transpose=True):
     """
@@ -119,70 +119,50 @@ def compress_fleuroutxml(outxmlfilepath, dest_file_path=None, delete_eig=True, i
      outxmlsrc = '/Users/broeder/test/FePt_out.xml'
      compress_fleuroutxml(outxmlsrc, dest_file_path=outxmldes, iterations_to_keep=14)
      compress_fleuroutxml(outxmlsrc, dest_file_path=outxmldes, iterations_to_keep=-1)
-
-
     """
-    from masci_tools.util.xml.common_functions import eval_xpath
-    from masci_tools.util.xml.xml_setters_basic import xml_delete_tag
+    from masci_tools.util.xml.xml_setters_names import delete_tag
+    from masci_tools.util.schema_dict_util import get_tag_xpath, get_number_of_nodes
+    from masci_tools.util.schema_dict_util import eval_simple_xpath
+    from masci_tools.io.io_fleurxml import load_outxml
     from lxml import etree
 
-    xpath_eig = '/fleurOutput/scfLoop/iteration/eigenvalues'
-    xpath_iter = '/fleurOutput/scfLoop/iteration'
-    tree = None
-    parser = etree.XMLParser(recover=False)
-    outfile_broken = False
-    try:
-        tree = etree.parse(outxmlfilepath, parser)
-    except etree.XMLSyntaxError:
-        outfile_broken = True
-        print('broken')
-
-    if outfile_broken:
-        # repair xmlfile and try to parse what is possible.
-        parser = etree.XMLParser(recover=True)
-        try:
-            tree = etree.parse(outxmlfilepath, parser)
-        except etree.XMLSyntaxError:
-            parse_xml = False
-            successful = False
-            print('failed to parse broken file, I abort.')
-            return
-
-    if tree is None:
-        print('xml tree is None, should not happen, ...')
-        return
+    xmltree, schema_dict = load_outxml(outxmlfilepath)
+    xpath_iteration = get_tag_xpath(schema_dict, 'iteration')
 
     # delete eigenvalues (all)
     if delete_eig:
-        new_etree = xml_delete_tag(tree, xpath_eig)
+        iteration_nodes = eval_simple_xpath(xmltree, schema_dict, 'iteration', list_return=True)
+        for iteration in iteration_nodes:
+            #The explicit conversion is done since delete_tag expects a ElementTree in masci-tools <= 0.6.2
+            delete_tag(etree.ElementTree(iteration), schema_dict, 'eigenvalues')
 
     # delete certain iterations
     if iterations_to_keep is not None:
-        root = new_etree.getroot()
-        iteration_nodes = eval_xpath(root, xpath_iter, list_return=True)
-        n_iters = len(iteration_nodes)
-        print(n_iters)
+        root = xmltree.getroot()
+        n_iters = get_number_of_nodes(root, schema_dict, 'iteration')
+        print(f'Found {n_iters} iterations')
         if iterations_to_keep < 0:
             # the first element has 1 (not 0) in xpath expresions
             position_keep = n_iters + iterations_to_keep + 1
-            delete_xpath = xpath_iter + f'[position()<{int(position_keep)}]'
+            delete_xpath = f'{xpath_iteration}[position()<{int(position_keep)}]'
         else:
-            delete_xpath = xpath_iter + f'[position()>{int(iterations_to_keep)}]'
+            delete_xpath = f'{xpath_iteration}[position()<{int(iterations_to_keep)}]'
 
         if abs(iterations_to_keep) > n_iters:
-            print('Warning: iterations_to_keep is larger then the number of iterations'
-                  ' in the given out.xml file, I keep all.')
+            warnings.warn('iterations_to_keep is larger then the number of iterations'
+                  ' in the given out.xml file, I keep all.', UserWarning)
         else:
-            print(delete_xpath)
-            new_etree = xml_delete_tag(new_etree, delete_xpath)
+            print(f'Deleting iterations under the xpath: {delete_xpath}')
+            xmltree = delete_tag(xmltree,schema_dict, 'iteration', complex_xpath=delete_xpath)
+
+    etree.indent(xmltree) #Make sure the print looks nice
 
     if dest_file_path is None:
         dest_file_path = outxmlfilepath  # overwrite file
-    if new_etree.getroot() is not None:  #otherwise write fails
-        new_etree.write(dest_file_path)
+    if xmltree.getroot() is not None:  #otherwise write fails
+        xmltree.write(dest_file_path, encoding='utf-8', pretty_print=True)
     else:
-        print('new_etree has no root..., I cannot write to proper xml, skipping this now')
-    return
+        raise ValueError('xmltree has no root..., I cannot write to proper xml')
 
 
 # usage example

--- a/aiida_fleur/workflows/corehole.py
+++ b/aiida_fleur/workflows/corehole.py
@@ -202,9 +202,7 @@ class FleurCoreholeWorkChain(WorkChain):
         Do some input checks. Further input checks are done in further workflow steps
         """
         # TODO: document parameters
-        self.report('started FleurCoreholeWorkChain version {} '
-                    'Workchain node identifiers: '  #{}"
-                    ''.format(self._workflowversion))  #, ProcessRegistry().current_calc_node))
+        self.report(f'started FleurCoreholeWorkChain version {self._workflowversion}')
 
         ### init ctx ###
 
@@ -301,8 +299,7 @@ class FleurCoreholeWorkChain(WorkChain):
         """
 
         supercell_base = self.ctx.supercell_size
-        description = ('WF, Creates a supercell of a crystal structure x({},{},{}).'
-                       ''.format(supercell_base[0], supercell_base[0], supercell_base[2]))
+        description = f'WF, Creates a supercell of a crystal structure x{tuple(supercell_base)}.'
 
         supercell_s = supercell(self.ctx.base_structure_relax,
                                 Int(supercell_base[0]),
@@ -314,8 +311,7 @@ class FleurCoreholeWorkChain(WorkChain):
                                 })
 
         # overwrite label and description of new structure
-        supercell_s.label = '{}x{}x{} of {}'.format(supercell_base[0], supercell_base[1], supercell_base[2],
-                                                    self.ctx.base_structure_relax.uuid)
+        supercell_s.label = f"{'x'.join(map(str,supercell_base))} of {self.ctx.base_structure_relax.uuid}"
         supercell_s.description = supercell_s.description + ' created in a FleurCoreholeWorkChain'
         self.ctx.ref_supercell = supercell_s
         calc_para = self.ctx.ref_para
@@ -436,9 +432,8 @@ class FleurCoreholeWorkChain(WorkChain):
                 try:
                     to_append = base_atoms_sites[atom_info]
                 except IndexError:
-                    error = ("ERROR: The index/integer: {} specified in 'atoms' key is not valid."
-                             'There are only {} atom sites in your provided structure.'
-                             ''.format(atom_info, len(base_atoms_sites)))
+                    error = (f"ERROR: The index/integer: {atom_info} specified in 'atoms' key is not valid."
+                             f'There are only {len(base_atoms_sites)} atom sites in your provided structure.')
                     to_append = None
                     self.report(error)
                 if to_append:
@@ -463,9 +458,9 @@ class FleurCoreholeWorkChain(WorkChain):
                 if len(elm_cl) != 2:
                     # something went wrong, wrong input
                     # TODO log, error and hint
-                    error = ('ERROR: corelevel was given in the wrong format: {},'
+                    error = (f'ERROR: corelevel was given in the wrong format: {elm_cl},'
                              'should have len 2. Hint hast to be the format '
-                             "['Element,corelevel',...] i.e ['Be,1s', 'W,all]".format(elm_cl))
+                             "['Element,corelevel',...] i.e ['Be,1s', 'W,all]")
                     self.control_end_wc(error)
                     return self.exit_codes.ERROR_IN_REFERENCE_CREATION
                 else:
@@ -565,27 +560,23 @@ class FleurCoreholeWorkChain(WorkChain):
                     fleurinp_change.append(change)
                     if correct_val_charge:  # only needed in certain methods
                         charge_change = (
-                            'add_num_to_att',
+                            'add_number_to_first_attrib',
                             {
-                                'xpathn': '/fleurInput/calculationSetup/bzIntegration',
                                 'attributename': 'valenceElectrons',
-                                'set_val': -1.0000,  #-hole_charge,  #one electron was added by ingen, we remove it
+                                'add_number': -1.0,  #-hole_charge,  #one electron was added by inpgen, we remove it
                                 'mode': 'abs',
-                                'occ': [0],
                             })
                         fleurinp_change.append(charge_change)
                     elif hole_charge != 1.0:  # fractional valence hole
                         charge_change = (
-                            'add_num_to_att',
+                            'add_number_to_first_attrib',
                             {
-                                'xpathn': '/fleurInput/calculationSetup/bzIntegration',
                                 'attributename': 'valenceElectrons',
-                                'set_val': -1.0000 + hole_charge,  # one electron was already added by inpgen
+                                'add_number': -1.0 + hole_charge,  # one electron was already added by inpgen
                                 'mode': 'abs',
-                                'occ': [0],
                             })
                         fleurinp_change.append(charge_change)
-                    if self.ctx.magnetic:  # Do a collinear magentic calculation
+                    if self.ctx.magnetic:  # Do a collinear magnetic calculation
                         charge_change = ('set_inpchanges', {'change_dict': {'jspins': 2}})
                         fleurinp_change.append(charge_change)
                     #self.report('{}'.format(fleurinp_change))

--- a/aiida_fleur/workflows/dmi.py
+++ b/aiida_fleur/workflows/dmi.py
@@ -244,7 +244,7 @@ class FleurDMIWorkChain(WorkChain):
 
         # change beta parameter
         for key, val in six.iteritems(self.ctx.wf_dict.get('beta')):
-            scf_wf_dict['inpxml_changes'].append(('set_atomgr_att_label', {
+            scf_wf_dict['inpxml_changes'].append(('set_atomgroup_label', {
                 'attributedict': {
                     'nocoParams': {
                         'beta': val

--- a/aiida_fleur/workflows/dmi.py
+++ b/aiida_fleur/workflows/dmi.py
@@ -290,35 +290,17 @@ class FleurDMIWorkChain(WorkChain):
         # copy inpchanges from wf parameters
         fchanges = self.ctx.wf_dict.get('inpxml_changes', [])
         # create forceTheorem tags
-        fchanges.extend([('create_tag', {
-            'xpath': '/fleurInput',
-            'newelement': 'forceTheorem'
-        }), ('create_tag', {
-            'xpath': '/fleurInput/forceTheorem',
-            'newelement': 'DMI'
-        }), ('create_tag', {
-            'xpath': '/fleurInput/forceTheorem/DMI',
-            'newelement': 'qVectors'
-        }),
-                         ('xml_set_attribv_occ', {
-                             'xpathn': '/fleurInput/forceTheorem/DMI',
-                             'attributename': 'theta',
-                             'attribv': ' '.join(six.moves.map(str, self.ctx.wf_dict.get('sqas_theta')))
-                         }),
-                         ('xml_set_attribv_occ', {
-                             'xpathn': '/fleurInput/forceTheorem/DMI',
-                             'attributename': 'phi',
-                             'attribv': ' '.join(six.moves.map(str, self.ctx.wf_dict.get('sqas_phi')))
-                         })])
-
-        for i, vectors in enumerate(self.ctx.wf_dict['q_vectors']):
-            fchanges.append(('create_tag', {'xpath': '/fleurInput/forceTheorem/DMI/qVectors', 'newelement': 'q'}))
-            fchanges.append(('xml_set_text_occ', {
-                'xpathn': '/fleurInput/forceTheorem/DMI/qVectors/q',
-                'text': ' '.join(six.moves.map(str, vectors)),
-                'create': False,
-                'occ': i
-            }))
+        fchanges.append(('set_complex_tag', {
+            'tag_name': 'DMI',
+            'create': True,
+            'changes': {
+                'qVectors': {
+                    'q': self.ctx.wf_dict['q_vectors']
+                },
+                'theta': self.ctx.wf_dict['sqas_theta'],
+                'phi': self.ctx.wf_dict['sqas_phi']
+            }
+        }))
 
         changes_dict = {
             'itmax': 1,
@@ -331,63 +313,57 @@ class FleurDMIWorkChain(WorkChain):
         fchanges.append(('set_inpchanges', {'change_dict': changes_dict}))
 
         # change beta parameter
-        for key, val in six.iteritems(self.ctx.wf_dict.get('beta')):
-            fchanges.append(('set_atomgr_att_label', {
+        for label, beta in self.ctx.wf_dict['beta'].items():
+            fchanges.append(('set_atomgroup_label', {
                 'attributedict': {
                     'nocoParams': {
-                        'beta': val
+                        'beta': beta
                     }
                 },
-                'atom_label': key
+                'atom_label': label
             }))
 
         # switch off SOC on an atom specie
         for atom_label in self.ctx.wf_dict['soc_off']:
             fchanges.append(('set_species_label', {
-                'at_label': atom_label,
+                'atom_label': atom_label,
                 'attributedict': {
                     'special': {
                         'socscale': 0.0
                     }
                 },
-                'create': True
             }))
 
         if fchanges:  # change inp.xml file
             fleurmode = FleurinpModifier(fleurin)
-            avail_ac_dict = fleurmode.get_avail_actions()
-
-            # apply further user dependend changes
-            for change in fchanges:
-                function = change[0]
-                para = change[1]
-                method = avail_ac_dict.get(function, None)
-                if not method:
-                    error = ("ERROR: Input 'inpxml_changes', function {} "
-                             'is not known to fleurinpmodifier class, '
-                             'please check/test your input. I abort...'
-                             ''.format(function))
-                    self.control_end_wc(error)
-                    return self.exit_codes.ERROR_CHANGING_FLEURINPUT_FAILED
-
-                else:  # apply change
-                    method(**para)
+            try:
+                fleurmode.add_task_list(fchanges)
+            except (ValueError, TypeError) as exc:
+                error = ('ERROR: Changing the inp.xml file failed. Tried to apply inpxml_changes'
+                         f', which failed with {exc}. I abort, good luck next time!')
+                self.control_end_wc(error)
+                return self.exit_codes.ERROR_CHANGING_FLEURINPUT_FAILED
 
             # validate?
             try:
                 fleurmode.show(display=False, validate=True)
             except etree.DocumentInvalid:
                 error = ('ERROR: input, user wanted inp.xml changes did not validate')
-                self.control_end_wc(error)
+                self.report(error)
                 return self.exit_codes.ERROR_INVALID_INPUT_FILE
+            except ValueError as exc:
+                error = ('ERROR: input, user wanted inp.xml changes could not be applied.'
+                         f'The following error was raised {exc}')
+                self.control_end_wc(error)
+                return self.exit_codes.ERROR_CHANGING_FLEURINPUT_FAILED
 
             # apply
             out = fleurmode.freeze()
             self.ctx.fleurinp = out
-            return
         else:  # otherwise do not change the inp.xml
             self.ctx.fleurinp = fleurin
-            return
+
+        return
 
     def force_after_scf(self):
         '''
@@ -509,8 +485,7 @@ class FleurDMIWorkChain(WorkChain):
         try:
             calculation = self.ctx.f_t
             if not calculation.is_finished_ok:
-                message = ('ERROR: Force theorem Fleur calculation failed somehow it has '
-                           'exit status {}'.format(calculation.exit_status))
+                message = f'ERROR: Force theorem Fleur calculation failed somehow it has exit status {calculation.exit_status}'
                 self.control_end_wc(message)
                 return self.exit_codes.ERROR_FORCE_THEOREM_FAILED
         except AttributeError:

--- a/aiida_fleur/workflows/relax.py
+++ b/aiida_fleur/workflows/relax.py
@@ -232,7 +232,7 @@ class FleurRelaxWorkChain(WorkChain):
         scf_wf_dict['mode'] = 'force'
 
         if self.ctx.wf_dict['film_distance_relaxation']:
-            scf_wf_dict['inpxml_changes'].append(('set_atomgr_att', {
+            scf_wf_dict['inpxml_changes'].append(('set_atomgroup', {
                 'attributedict': {
                     'force': {
                         'relaxXYZ': 'FFT'
@@ -242,7 +242,7 @@ class FleurRelaxWorkChain(WorkChain):
             }))
 
         for specie_off in self.ctx.wf_dict['atoms_off']:
-            scf_wf_dict['inpxml_changes'].append(('set_atomgr_att_label', {
+            scf_wf_dict['inpxml_changes'].append(('set_atomgroup_label', {
                 'attributedict': {
                     'force': {
                         'relaxXYZ': 'FFF'
@@ -251,7 +251,7 @@ class FleurRelaxWorkChain(WorkChain):
                 'atom_label': specie_off
             }))
 
-        scf_wf_dict['inpxml_changes'].append(('set_atomgr_att_label', {
+        scf_wf_dict['inpxml_changes'].append(('set_atomgroup_label', {
             'attributedict': {
                 'force': {
                     'relaxXYZ': 'FFF'

--- a/aiida_fleur/workflows/ssdisp.py
+++ b/aiida_fleur/workflows/ssdisp.py
@@ -229,7 +229,7 @@ class FleurSSDispWorkChain(WorkChain):
 
         # change beta parameter
         for key, val in six.iteritems(self.ctx.wf_dict.get('beta')):
-            scf_wf_dict['inpxml_changes'].append(('set_atomgr_att_label', {
+            scf_wf_dict['inpxml_changes'].append(('set_atomgroup_label', {
                 'attributedict': {
                     'nocoParams': {
                         'beta': val

--- a/aiida_fleur/workflows/ssdisp_conv.py
+++ b/aiida_fleur/workflows/ssdisp_conv.py
@@ -136,7 +136,7 @@ class FleurSSDispConvWorkChain(WorkChain):
 
         # change beta parameter
         for key, val in six.iteritems(self.ctx.wf_dict.get('beta')):
-            scf_wf_dict['inpxml_changes'].append(('set_atomgr_att_label', {
+            scf_wf_dict['inpxml_changes'].append(('set_atomgroup_label', {
                 'attributedict': {
                     'nocoParams': {
                         'beta': val

--- a/docs/source/user_guide/data/fleurinp_data.rst
+++ b/docs/source/user_guide/data/fleurinp_data.rst
@@ -165,4 +165,4 @@ line to ``inpxml_changes`` of workchain parameters:
   # in this example the atomgroup, to which the atom with label '222' belongs,
   # will be modified
   fm = FleurinpModifier(SomeFleurinp)
-  fm.set_atomgr_att_label(attributedict={'force': {'relaxXYZ': 'FFF'}, atom_label='                 222')
+  fm.set_atomgroup_label(attributedict={'force': {'relaxXYZ': 'FFF'}, atom_label='                 222')

--- a/tests/tools/test_io_routines.py
+++ b/tests/tools/test_io_routines.py
@@ -79,7 +79,7 @@ def test_compress_fleuroutxml(eval_xpath):
     niter1 = get_npath(dest_path, xpath_iter)
     neig = get_npath(dest_path, xpath_eig)
 
-    assert isfile  # check outfile
+    assert isfile_  # check outfile
     assert niter1 == 15  # check if 15 iterations are kept
     assert neig == 0  # check if eigenvalues del
 
@@ -89,13 +89,15 @@ def test_compress_fleuroutxml(eval_xpath):
     assert niter2 == 1  # check of only one iteration kept
 
     # test if more iteration given then in file should change nothing
-    compress_fleuroutxml(testfilepath, dest_file_path=dest_path, iterations_to_keep=25)
+    with pytest.warns(UserWarning, match='iterations_to_keep is larger then the number of iterations'):
+        compress_fleuroutxml(testfilepath, dest_file_path=dest_path, iterations_to_keep=25)
     niter3 = get_npath(dest_path, xpath_iter)
 
     assert niter3 == niter_file  # check if no iteration deleted
 
     # test if broken file will not generate an error
-    compress_fleuroutxml(testfilepath_broken, dest_file_path=dest_path2, iterations_to_keep=25)
+    with pytest.warns(UserWarning, match='The out.xml file is broken'):
+        compress_fleuroutxml(testfilepath_broken, dest_file_path=dest_path2, iterations_to_keep=25)
 
     # cleanup
     remove(dest_path)


### PR DESCRIPTION
Closes #6 

Follow up for #111, #115 and #116. Cleans up the remaining places where explicit xpaths were used in the  package

- `extract_corelevels` is deprecated, since the `outxml_parser` in masci-tools can now extract core levels (optionally). A hint how to do this is shown in the DeprecationWarning
- `compress_fleuroutxml` is moved to the new modification routines, since it can be useful to cleanup calculations after the fact. However the interface has to be cleaned up
- Workchains using explicit xpath routines were improved (DMI, MAE, SSDisp and Corehole)