### PR TITLE
Allow etree.Elements in Fleurinpmodfier

### DIFF
--- a/aiida_fleur/data/fleurinpmodifier.py
+++ b/aiida_fleur/data/fleurinpmodifier.py
@@ -312,17 +312,22 @@ class FleurinpModifier(FleurXMLModifier):
         :param occurrences: int or list of int. Which occurence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
-        self._validate_signature('xml_create_tag', *args, **kwargs)
+        self._validate_arguments('xml_create_tag', args, kwargs)
 
-        if 'element' in kwargs:
-            element = kwargs
-        else:
+        element = kwargs.get('element')
+        if element is None:
             element = args[1]
 
         if etree.iselement(element):
-            warnings.warn('Creating a tag from a given etree Element is only supported via the show()'
-                          'and validate() methods on the Fleurinpmodifier and cannot be used with freeze()')
-
+            element = etree.tostring(element, encoding='unicode', pretty_print=True)
+            if 'element' in kwargs:
+                kwargs['element'] = element
+            else:
+                if len(args) > 2:
+                    args = args[0], element, *args[2:]
+                else:
+                    args = args[0], element
+        print(args, kwargs)
         super().xml_create_tag(*args, **kwargs)
 
     def create_tag(self, *args, **kwargs):
@@ -368,14 +373,20 @@ class FleurinpModifier(FleurXMLModifier):
 
             self.xml_create_tag(xpath, element, *args, **kwargs)
         else:
+            self._validate_arguments('create_tag', args, kwargs)
             tag = kwargs.get('tag')
             if tag is None:
                 tag = args[0]
 
             if etree.iselement(tag):
-                warnings.warn('Creating a tag from a given etree Element is only supported via the show()'
-                              'and validate() methods on the Fleurinpmodifier and cannot be used with freeze()')
-
+                tag = etree.tostring(tag, encoding='unicode', pretty_print=True)
+                if 'tag' in kwargs:
+                    kwargs['tag'] = tag
+                elif len(args) > 1:
+                    args = tag, *args[1:]
+                else:
+                    args = (tag,)
+            print(args, kwargs)
             super().create_tag(*args, **kwargs)
 
     def delete_tag(self, *args, **kwargs):
@@ -463,14 +474,25 @@ class FleurinpModifier(FleurXMLModifier):
         the list of tasks that will be done on the xmltree.
 
         :param xpath: a path to the tag to be replaced
-        :param newelement: a new tag
+        :param element: a new tag
         :param occurrences: int or list of int. Which occurence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
-        self._validate_signature('xml_replace_tag', *args, **kwargs)
+        self._validate_arguments('xml_replace_tag', args, kwargs)
 
-        warnings.warn('Creating a tag from a given etree Element is only supported via the show()'
-                      'and validate() methods on the Fleurinpmodifier and cannot be used with freeze()')
+        element = kwargs.get('element')
+        if element is None:
+            element = args[1]
+
+        if etree.iselement(element):
+            element = etree.tostring(element, encoding='unicode', pretty_print=True)
+            if 'element' in kwargs:
+                kwargs['element'] = element
+            else:
+                if len(args) > 2:
+                    args = args[0], element, *args[2:]
+                else:
+                    args = args[0], element
 
         super().xml_replace_tag(*args, **kwargs)
 
@@ -493,9 +515,6 @@ class FleurinpModifier(FleurXMLModifier):
             :param not_contains: str, this string has to NOT be in the final path
         """
 
-        warnings.warn('Replacing a tag with a given etree Element is only supported via the show()'
-                      'and validate() methods on the Fleurinpmodifier and cannot be used with freeze()')
-
         old_interface = 'xpath' in kwargs
         if args:
             old_interface = old_interface or '/' in args[0]
@@ -514,6 +533,20 @@ class FleurinpModifier(FleurXMLModifier):
 
             self.xml_replace_tag(xpath, *args, **kwargs)
         else:
+            self._validate_arguments('replace_tag', args, kwargs)
+            element = kwargs.get('element')
+            if element is None:
+                element = args[1]
+
+            if etree.iselement(element):
+                element = etree.tostring(element, encoding='unicode', pretty_print=True)
+                if 'element' in kwargs:
+                    kwargs['element'] = element
+                elif len(args) > 2:
+                    args = args[0], element, *args[2:]
+                else:
+                    args = args[0], element
+
             super().replace_tag(*args, **kwargs)
 
     def add_num_to_att(self, *args, **kwargs):

--- a/aiida_fleur/data/fleurinpmodifier.py
+++ b/aiida_fleur/data/fleurinpmodifier.py
@@ -327,7 +327,7 @@ class FleurinpModifier(FleurXMLModifier):
                     args = args[0], element, *args[2:]
                 else:
                     args = args[0], element
-        print(args, kwargs)
+
         super().xml_create_tag(*args, **kwargs)
 
     def create_tag(self, *args, **kwargs):
@@ -386,7 +386,7 @@ class FleurinpModifier(FleurXMLModifier):
                     args = tag, *args[1:]
                 else:
                     args = (tag,)
-            print(args, kwargs)
+
             super().create_tag(*args, **kwargs)
 
     def delete_tag(self, *args, **kwargs):

--- a/docs/source/user_guide/data/fleurinp_modifier.rst
+++ b/docs/source/user_guide/data/fleurinp_modifier.rst
@@ -164,14 +164,14 @@ The figure below shows a comparison between the use of XML and shortcut methods.
     * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.add_num_to_att()` was renamed to :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.add_number_to_attrib()` or :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.add_number_to_first_attrib()`. However, these are also higher-level functions now longer requiring a concrete xpath
     * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.set_atomgr_att()` and :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.set_atomgr_att_label()` were renamed to :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.set_atomgroup()` and :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.set_atomgroup_label()`. These functions now also take the changes in the form ``attributedict={'nocoParams':{'beta': val}}`` instead of ``attributedict={'nocoParams':[('beta': val)]}``
 
-.. warning:: Passing XML Elements to modification functions
+.. .. warning:: Passing XML Elements to modification functions
 
-    Some of the low-level implementations of the XML modification functions accept explicit XML elements as arguments for replacing/inserting. However, these can only be used within limits in the :py:class:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier` at the moment. The reason for this is that there is currently no support for serializing these objects for the input of the Aiida calcfunction. The following functions are affected by this:
+..     Some of the low-level implementations of the XML modification functions accept explicit XML elements as arguments for replacing/inserting. However, these can only be used within limits in the :py:class:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier` at the moment. The reason for this is that there is currently no support for serializing these objects for the input of the Aiida calcfunction. The following functions are affected by this:
 
-    * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.xml_replace_tag()` (Only usable with show and validate)
-    * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.replace_tag()` (Only usable with show and validate)
-    * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.xml_create_tag()` (Can only be used with string names of tags)
-    * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.create_tag()`  (Can only be used with string names of tags)
+..     * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.xml_replace_tag()` (Only usable with show and validate)
+..     * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.replace_tag()` (Only usable with show and validate)
+..     * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.xml_create_tag()` (Can only be used with string names of tags)
+..     * :py:func:`~aiida_fleur.data.fleurinpmodifier.FleurinpModifier.create_tag()`  (Can only be used with string names of tags)
 
 Modifying the density matrix for LDA+U calculations
 ---------------------------------------------------

--- a/tests/data/test_fleurinpmodifier.py
+++ b/tests/data/test_fleurinpmodifier.py
@@ -280,3 +280,35 @@ def test_fleurinpmodifier_error_messages(create_fleurinp):
         fm.freeze()
 
     fm = FleurinpModifier(fleurinp_tmp)
+
+
+def test_fleurinpmodifier_element_serialization(create_fleurinp):
+    """Tests of fleurinpmodifier registration methods accepting etree.Elements as arguments
+    If any of these don't serialize the elements correctly you will see an error that etree.fromstring
+    is passed an empty list (This is a weird side effect for etree._Element of the automatic serialization done in aiida-core)
+    """
+    from lxml import etree
+    fleurinp_tmp = create_fleurinp(inpxmlfilefolder)
+
+    fm = FleurinpModifier(fleurinp_tmp)
+    fm.create_tag(etree.Element('expertModes'))
+    fm.delete_tag('expertModes')
+    fm.create_tag(tag=etree.Element('expertModes'))
+    fm.delete_tag('expertModes')
+    fm.create_tag(etree.Element('expertModes'), '/fleurInput/calculationSetup')
+    fm.delete_tag('expertModes')
+    fm.xml_create_tag('/fleurInput/calculationSetup', etree.Element('expertModes'))
+    fm.delete_tag('expertModes')
+    fm.xml_create_tag('/fleurInput/calculationSetup', element=etree.Element('expertModes'))
+    fm.delete_tag('expertModes')
+    fm.xml_create_tag('/fleurInput/calculationSetup', etree.Element('expertModes'), 0)
+
+    fm.replace_tag('expertModes', etree.Element('expertModes'))
+    fm.replace_tag('expertModes', element=etree.Element('expertModes'))
+    fm.replace_tag('expertModes', etree.Element('expertModes'), '/fleurInput/calculationSetup/expertModes')
+    fm.xml_replace_tag('/fleurInput/calculationSetup/expertModes', etree.Element('expertModes'))
+    fm.xml_replace_tag('/fleurInput/calculationSetup/expertModes', element=etree.Element('expertModes'))
+    fm.xml_replace_tag('/fleurInput/calculationSetup/expertModes', etree.Element('expertModes'), 0)
+
+    fm.show()
+    fm.freeze()


### PR DESCRIPTION
WIP: since the needed modifications in masci-tools are not released
Serialize the passed etree._Elements in `create_tag`/`replace_tag` to strings. These are then detected and reconstructed inside `masci-tools`