### PR TITLE
Deprecate `rel_to_abs`, `rel_to_abs_f`, `abs_to_rel` and `abs_to_rel_f`

### DIFF
--- a/aiida_fleur/tools/StructureData_util.py
+++ b/aiida_fleur/tools/StructureData_util.py
@@ -17,6 +17,7 @@ Collection of utility routines dealing with StructureData objects
 # from ase.lattice.surface import *
 # from ase.io import *
 
+import warnings
 from pymatgen.core.surface import generate_all_slabs  #, get_symmetrically_distinct_miller_indices
 from pymatgen.core.surface import SlabGenerator
 
@@ -217,17 +218,11 @@ def abs_to_rel(vector, cell):
     :param cell: Bravais matrix of a crystal 3x3 Array, List of list or np.array
     :return: list of legth 3 of scaled vector, or False if vector was not length 3
     """
-
-    if len(vector) == 3:
-        cell_np = np.array(cell)
-        inv_cell_np = np.linalg.inv(cell_np)
-        postionR = np.array(vector)
-        # np.matmul(inv_cell_np, postionR)#
-        new_rel_post = np.matmul(postionR, inv_cell_np)
-        new_rel_pos = list(new_rel_post)
-        return new_rel_pos
-    else:
-        return False
+    warnings.warn(
+        'abs_to_rel will be removed from StructureData_util in the future.'
+        'Use the same function from masci_tools.io.common_functions', DeprecationWarning)
+    from masci_tools.io.common_functions import abs_to_rel  #pylint: disable=redefined-outer-name
+    return abs_to_rel(vector, cell)
 
 
 def abs_to_rel_f(vector, cell, pbc):
@@ -240,26 +235,11 @@ def abs_to_rel_f(vector, cell, pbc):
     :param pbc: Boundary conditions, List or Tuple of 3 Boolean
     :return: list of legth 3 of scaled vector, or False if vector was not length 3
     """
-    # TODO this currently only works if the z-coordinate is the one with no pbc
-    # Therefore if a structure with x non pbc is given this should also work.
-    # maybe write a 'tranform film to fleur_film routine'?
-    if len(vector) == 3:
-        if not pbc[2]:
-            # leave z coordinate absolute
-            # convert only x and y.
-            postionR = np.array(vector)
-            postionR_f = np.array(postionR[:2])
-            cell_np = np.array(cell)
-            cell_np = np.array(cell_np[0:2, 0:2])
-            inv_cell_np = np.linalg.inv(cell_np)
-            # np.matmul(inv_cell_np, postionR_f)]
-            new_xy = np.matmul(postionR_f, inv_cell_np)
-            new_rel_pos_f = [new_xy[0], new_xy[1], postionR[2]]
-            return new_rel_pos_f
-        else:
-            print('FLEUR can not handle this type of film coordinate')
-    else:
-        return False
+    warnings.warn(
+        'abs_to_rel_f will be removed from StructureData_util in the future.'
+        'Use the same function from masci_tools.io.common_functions', DeprecationWarning)
+    from masci_tools.io.common_functions import abs_to_rel_f  #pylint: disable=redefined-outer-name
+    return abs_to_rel_f(vector, cell, pbc)
 
 
 def rel_to_abs(vector, cell):
@@ -271,14 +251,11 @@ def rel_to_abs(vector, cell):
     :param cell: Bravais matrix of a crystal 3x3 Array, List of list or np.array
     :return: list of legth 3 of scaled vector, or False if vector was not lenth 3
     """
-    if len(vector) == 3:
-        cell_np = np.array(cell)
-        postionR = np.array(vector)
-        new_abs_post = np.matmul(postionR, cell_np)
-        new_abs_pos = list(new_abs_post)
-        return new_abs_pos
-    else:
-        return False
+    warnings.warn(
+        'rel_to_abs will be removed from StructureData_util in the future.'
+        'Use the same function from masci_tools.io.common_functions', DeprecationWarning)
+    from masci_tools.io.common_functions import rel_to_abs  #pylint: disable=redefined-outer-name
+    return rel_to_abs(vector, cell)
 
 
 def rel_to_abs_f(vector, cell):
@@ -286,19 +263,11 @@ def rel_to_abs_f(vector, cell):
     Converts a position vector in internal coordinates to absolute coordinates
     in Angstrom for a film structure (2D).
     """
-    # TODO this currently only works if the z-coordinate is the one with no pbc
-    # Therefore if a structure with x non pbc is given this should also work.
-    # maybe write a 'tranform film to fleur_film routine'?
-    if len(vector) == 3:
-        postionR = np.array(vector)
-        postionR_f = np.array(postionR[:2])
-        cell_np = np.array(cell)
-        cell_np = np.array(cell_np[0:2, 0:2])
-        new_xy = np.matmul(postionR_f, cell_np)
-        new_abs_pos_f = [new_xy[0], new_xy[1], postionR[2]]
-        return new_abs_pos_f
-    else:
-        return False
+    warnings.warn(
+        'rel_to_abs_f will be removed from StructureData_util in the future.'
+        'Use the same function from masci_tools.io.common_functions', DeprecationWarning)
+    from masci_tools.io.common_functions import rel_to_abs_f  #pylint: disable=redefined-outer-name
+    return rel_to_abs_f(vector, cell)
 
 
 @cf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -597,22 +597,7 @@ def generate_structure2():
     def _generate_structure2():
         """Return a `StructureData` representing bulk silicon."""
         from aiida.orm import StructureData
-
-        def rel_to_abs(vector, cell):
-            """
-            converts interal coordinates to absolut coordinates in Angstroem.
-            """
-            if len(vector) == 3:
-                postionR = vector
-                row1 = cell[0]
-                row2 = cell[1]
-                row3 = cell[2]
-                new_abs_pos = [
-                    postionR[0] * row1[0] + postionR[1] * row2[0] + postionR[2] * row3[0],
-                    postionR[0] * row1[1] + postionR[1] * row2[1] + postionR[2] * row3[1],
-                    postionR[0] * row1[2] + postionR[1] * row2[2] + postionR[2] * row3[2]
-                ]
-                return new_abs_pos
+        from masci_tools.io.common_functions import rel_to_abs
 
         bohr_a_0 = 0.52917721092  # A
         a = 5.167355275190 * bohr_a_0

--- a/tests/tools/test_StructureData_util.py
+++ b/tests/tools/test_StructureData_util.py
@@ -119,8 +119,11 @@ def test_abs_to_rel(generate_structure):
     cell = structure.cell
 
     vector = [1.3575, 1.3575, 1.3575]
-    assert np.isclose(abs_to_rel(vector, cell), np.array([0.25, 0.25, 0.25])).all()
-    assert not abs_to_rel([1], cell)
+    with pytest.deprecated_call():
+        assert np.isclose(abs_to_rel(vector, cell), np.array([0.25, 0.25, 0.25])).all()
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError):
+            assert not abs_to_rel([1], cell)
 
 
 def test_abs_to_rel_f(generate_film_structure):
@@ -130,8 +133,11 @@ def test_abs_to_rel_f(generate_film_structure):
     cell = structure.cell
 
     vector = [1.4026317387183, 1.9836207751336, 0.25]
-    assert np.isclose(abs_to_rel_f(vector, cell, pbc=structure.pbc), np.array([0.5, 0.5, 0.25])).all()
-    assert not abs_to_rel_f([1], cell, pbc=structure.pbc)
+    with pytest.deprecated_call():
+        assert np.isclose(abs_to_rel_f(vector, cell, pbc=structure.pbc), np.array([0.5, 0.5, 0.25])).all()
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError):
+            abs_to_rel_f([1], cell, pbc=structure.pbc)
 
 
 def test_rel_to_abs(generate_structure):
@@ -142,8 +148,11 @@ def test_rel_to_abs(generate_structure):
     cell = structure.cell
 
     vector = [0.25, 0.25, 0.25]
-    assert np.isclose(rel_to_abs(vector, cell), np.array([1.3575, 1.3575, 1.3575])).all()
-    assert not rel_to_abs([1], cell)
+    with pytest.deprecated_call():
+        assert np.isclose(rel_to_abs(vector, cell), np.array([1.3575, 1.3575, 1.3575])).all()
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError):
+            assert not rel_to_abs([1], cell)
 
 
 def test_rel_to_abs_f(generate_film_structure):
@@ -154,8 +163,11 @@ def test_rel_to_abs_f(generate_film_structure):
     cell = structure.cell
 
     vector = [0.5, 0.5, 0.25]
-    assert np.isclose(rel_to_abs_f(vector, cell), np.array([1.4026317387183, 1.9836207751336, 0.25])).all()
-    assert not rel_to_abs_f([1], cell)
+    with pytest.deprecated_call():
+        assert np.isclose(rel_to_abs_f(vector, cell), np.array([1.4026317387183, 1.9836207751336, 0.25])).all()
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError):
+            assert not rel_to_abs_f([1], cell)
 
 
 def test_break_symmetry_wf_film_structure_only(generate_film_structure):


### PR DESCRIPTION
These functions are completely covered in `masci_tools.io.common_functions`
Replaced function bodies with just calling the masci-tools functions