### PR TITLE
Remove UUIDs from output dictionaries

### DIFF
--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -491,12 +491,6 @@ class FleurBandDosWorkChain(WorkChain):
         if self.ctx.banddos_calc:
             self.report(f'A bandstructure/DOS was calculated and is found under pk={self.ctx.banddos_calc.pk}, '
                         f'calculation {self.ctx.banddos_calc}')
-            try:
-                last_calc_uuid = find_last_submitted_calcjob(self.ctx.banddos_calc)
-            except NotExistent:
-                last_calc_uuid = None
-        else:
-            last_calc_uuid = None
 
         try:  # if something failed, we still might be able to retrieve something
             last_calc_out = self.ctx.banddos_calc.outputs.output_parameters
@@ -556,7 +550,6 @@ class FleurBandDosWorkChain(WorkChain):
         outputnode_dict['workflow_name'] = self.__class__.__name__
         outputnode_dict['Warnings'] = self.ctx.warnings
         outputnode_dict['successful'] = self.ctx.successful
-        outputnode_dict['last_calc_uuid'] = last_calc_uuid
         outputnode_dict['mode'] = self.ctx.wf_dict.get('mode')
         outputnode_dict['fermi_energy_band'] = efermi_band
         outputnode_dict['bandgap_band'] = bandgap_band

--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -44,7 +44,7 @@ class FleurBandDosWorkChain(WorkChain):
     # wf_parameters: {  'tria', 'nkpts', 'sigma', 'emin', 'emax'}
     # defaults : tria = True, nkpts = 800, sigma=0.005, emin= , emax =
 
-    _workflowversion = '0.5.2'
+    _workflowversion = '0.6.0'
 
     _default_options = {
         'resources': {

--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -487,7 +487,6 @@ class FleurBandDosWorkChain(WorkChain):
         # TODO more here
         self.report('BandDOS workflow Done')
 
-        from aiida_fleur.tools.common_fleur_wf import find_last_submitted_calcjob
         if self.ctx.banddos_calc:
             self.report(f'A bandstructure/DOS was calculated and is found under pk={self.ctx.banddos_calc.pk}, '
                         f'calculation {self.ctx.banddos_calc}')

--- a/aiida_fleur/workflows/base_fleur.py
+++ b/aiida_fleur/workflows/base_fleur.py
@@ -66,7 +66,6 @@ class FleurBaseWorkChain(BaseRestartWorkChain):
         )
 
         spec.expose_outputs(FleurCalculation)
-        spec.output('final_calc_uuid', valid_type=orm.Str, required=False)
 
         spec.exit_code(311,
                        'ERROR_VACUUM_SPILL_RELAX',

--- a/aiida_fleur/workflows/base_relax.py
+++ b/aiida_fleur/workflows/base_relax.py
@@ -274,7 +274,7 @@ class FleurBaseRelaxWorkChain(BaseRestartWorkChain):
         xmltree, schema_dict = calculation.outputs.last_scf.fleurinp.load_inpxml()
         mixing = evaluate_attribute(xmltree, schema_dict, 'forcemix', optional=True)
         if not mixing:
-            mixing = "BFGS"
+            mixing = 'BFGS'
 
         if value < -0.2 and error_params['iteration_number'] >= 3 and mixing == 'BFGS':
             self.ctx.initial_mixing = 'straight'

--- a/aiida_fleur/workflows/corehole.py
+++ b/aiida_fleur/workflows/corehole.py
@@ -1128,7 +1128,7 @@ def extract_results_corehole(calcs):
         print(calc.exit_status, calc.exit_message)
         print(calc.get_outgoing().all())
         try:
-            calc_uuid = calc.outputs.output_scf_wc_para.get_dict()['last_calc_uuid']
+            calc_uuid = calc.outputs.last_calc.remote_folder.creator.uuid
         except (KeyError, AttributeError):
             print('continue')
             continue

--- a/aiida_fleur/workflows/initial_cls.py
+++ b/aiida_fleur/workflows/initial_cls.py
@@ -940,7 +940,7 @@ def extract_results(calcs):
     for calc in calcs:
         #print(calc)
         try:
-            calc_uuid = calc.get_outgoing().get_node_by_label('output_scf_wc_para').get_dict()['last_calc_uuid']
+            calc_uuid = calc.outputs.last_calc.remote_folder.creator.uuid
         except (NotExistent, MultipleObjectsError, ValueError, TypeError, KeyError):  #TODO which error
             logmsg = ('ERROR: No output_scf_wc_para node found or no "last_calc_uuid" '
                       'key in it for calculation: {}'.format(calc))

--- a/aiida_fleur/workflows/initial_cls.py
+++ b/aiida_fleur/workflows/initial_cls.py
@@ -942,13 +942,11 @@ def extract_results(calcs):
         try:
             calc_uuid = calc.outputs.last_calc.remote_folder.creator.uuid
         except (NotExistent, MultipleObjectsError, ValueError, TypeError, KeyError):  #TODO which error
-            logmsg = ('ERROR: No output_scf_wc_para node found or no "last_calc_uuid" '
-                      'key in it for calculation: {}'.format(calc))
+            logmsg = f'ERROR: No FleurCalculation node found in SCF workchain: {calc.uuid}'
             log.append(logmsg)
             continue
         if calc_uuid is not None:
             calc_uuids.append(calc_uuid)
-        #calc_uuids.append(calc['output_scf_wc_para'].get_dict()['last_calc_uuid'])
 
     all_corelevels = {}
     fermi_energies = {}

--- a/aiida_fleur/workflows/relax.py
+++ b/aiida_fleur/workflows/relax.py
@@ -32,7 +32,7 @@ class FleurRelaxWorkChain(WorkChain):
     This workflow performs structure optimization.
     """
 
-    _workflowversion = '0.4.1'
+    _workflowversion = '0.5.0'
 
     _default_wf_para = {
         'relax_iter': 5,  # Stop if not converged after so many relaxation steps

--- a/aiida_fleur/workflows/relax.py
+++ b/aiida_fleur/workflows/relax.py
@@ -525,9 +525,6 @@ class FleurRelaxWorkChain(WorkChain):
             'errors': self.ctx.errors,
             'force': self.ctx.forces,
             'force_iter_done': self.ctx.loop_count,
-            # uuids in the output are bad for caching should be avoided,
-            # instead better return the node.
-            'last_scf_wc_uuid': self.ctx.scf_res.uuid,
             'total_magnetic_moment_cell': self.ctx.total_magnetic_moment,
             'total_magnetic_moment_cell_units': 'muBohr'
         }

--- a/aiida_fleur/workflows/scf.py
+++ b/aiida_fleur/workflows/scf.py
@@ -27,7 +27,6 @@ from aiida.common.exceptions import NotExistent
 from aiida_fleur.data.fleurinpmodifier import FleurinpModifier
 from aiida_fleur.tools.common_fleur_wf import get_inputs_fleur, get_inputs_inpgen
 from aiida_fleur.tools.common_fleur_wf import test_and_get_codenode
-from aiida_fleur.tools.common_fleur_wf import find_last_submitted_calcjob
 from aiida_fleur.tools.create_kpoints_from_distance import create_kpoints_from_distance_parameter
 from aiida_fleur.workflows.base_fleur import FleurBaseWorkChain
 from aiida_fleur.calculation.fleur import FleurCalculation
@@ -765,13 +764,6 @@ class FleurScfWorkChain(WorkChain):
         This should run through and produce output nodes even if everything failed,
         therefore it only uses results from context.
         """
-        if self.ctx.last_base_wc:
-            try:
-                last_calc_uuid = find_last_submitted_calcjob(self.ctx.last_base_wc)
-            except NotExistent:
-                last_calc_uuid = None
-        else:
-            last_calc_uuid = None
 
         try:  # if something failed, we still might be able to retrieve something
             last_calc_out = self.ctx.last_base_wc.outputs.output_parameters
@@ -803,7 +795,6 @@ class FleurScfWorkChain(WorkChain):
         outputnode_dict['total_energy_units'] = 'Htr'
         outputnode_dict['nmmp_distance'] = last_nmmp_distance
         outputnode_dict['nmmp_distance_all'] = self.ctx.nmmp_distance
-        outputnode_dict['last_calc_uuid'] = last_calc_uuid
         outputnode_dict['total_wall_time'] = self.ctx.total_wall_time
         outputnode_dict['total_wall_time_units'] = 's'
         outputnode_dict['info'] = self.ctx.info

--- a/aiida_fleur/workflows/scf.py
+++ b/aiida_fleur/workflows/scf.py
@@ -58,7 +58,7 @@ class FleurScfWorkChain(WorkChain):
         like Success, last result node, list with convergence behavior
     """
 
-    _workflowversion = '0.5.3'
+    _workflowversion = '0.6.0'
     _default_wf_para = {
         'fleur_runmax': 4,
         'density_converged': 0.00002,

--- a/aiida_fleur/workflows/strain.py
+++ b/aiida_fleur/workflows/strain.py
@@ -279,7 +279,7 @@ class FleurStrainWorkChain(WorkChain):
             t_energylist_peratom.append(t_e / natoms)
             vol_peratom_success.append(self.ctx.volume_peratom[label])
             distancelist.append(dis)
-            calc_uuid = outpara.get('last_calc_uuid')
+            calc_uuid = calc.outputs.last_calc.remote_folder.creator.uuid
             calc_uuids.append(calc_uuid)
             bandgaplist.append(load_node(calc_uuid).res.bandgap)
 

--- a/docs/source/user_guide/workflows/code/scf_wc_outputnode.py
+++ b/docs/source/user_guide/workflows/code/scf_wc_outputnode.py
@@ -13,7 +13,6 @@
     'force_largest': 0.0,
     'info': [],
     'iterations_total': 23,
-    'last_calc_uuid': 'b20b5b94-5d80-41a8-82bf-b4d8eee9bddc',
     'loop_count': 1,
     'material': 'FePt2',
     'total_energy': -38166.176928494,

--- a/tests/workflows/test_banddos_workchain.py
+++ b/tests/workflows/test_banddos_workchain.py
@@ -25,7 +25,7 @@ CALC2_ENTRY_POINT = 'fleur.inpgen'
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog):
+def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog, show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Calls scf, Several fleur runs needed till convergence
@@ -69,14 +69,12 @@ def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleu
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_banddos_wc_para']
     n = n.get_dict()
-
-    print(get_calcjob_report(orm.load_node(n['last_calc_uuid'])))
 
     #print(n)
     efermi = 0.2034799610
@@ -94,7 +92,7 @@ def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleu
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_dos_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog):
+def test_fleur_dos_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog, show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Calls scf, Several fleur runs needed till convergence
@@ -143,14 +141,12 @@ def test_fleur_dos_fleurinp_Si(with_export_cache, fleur_local_code, create_fleur
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_banddos_wc_para']
     n = n.get_dict()
-
-    print(get_calcjob_report(orm.load_node(n['last_calc_uuid'])))
 
     #print(n)
     efermi = 0.2034799610
@@ -169,7 +165,7 @@ def test_fleur_dos_fleurinp_Si(with_export_cache, fleur_local_code, create_fleur
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
 def test_fleur_band_fleurinp_Si_seekpath(with_export_cache, fleur_local_code, create_fleurinp, clear_database,
-                                         aiida_caplog):
+                                         aiida_caplog, show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Uses seekpath to determine the path for the bandstructure
@@ -217,14 +213,12 @@ def test_fleur_band_fleurinp_Si_seekpath(with_export_cache, fleur_local_code, cr
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_banddos_wc_para']
     n = n.get_dict()
-
-    print(get_calcjob_report(orm.load_node(n['last_calc_uuid'])))
 
     #print(n)
     efermi = 0.2034799610
@@ -242,7 +236,7 @@ def test_fleur_band_fleurinp_Si_seekpath(with_export_cache, fleur_local_code, cr
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_band_fleurinp_Si_ase(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog):
+def test_fleur_band_fleurinp_Si_ase(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Uses ase bandpath to determine the path through the briloouin zone
@@ -290,14 +284,12 @@ def test_fleur_band_fleurinp_Si_ase(with_export_cache, fleur_local_code, create_
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_banddos_wc_para']
     n = n.get_dict()
-
-    print(get_calcjob_report(orm.load_node(n['last_calc_uuid'])))
 
     #print(n)
     efermi = 0.2034799610
@@ -316,7 +308,7 @@ def test_fleur_band_fleurinp_Si_ase(with_export_cache, fleur_local_code, create_
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
 def test_fleur_band_remote_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,
-                              get_remote_data_si):
+                              get_remote_data_si, show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Calls scf, Several fleur runs needed till convergence
@@ -358,14 +350,12 @@ def test_fleur_band_remote_Si(with_export_cache, fleur_local_code, create_fleuri
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_banddos_wc_para']
     n = n.get_dict()
-
-    print(get_calcjob_report(orm.load_node(n['last_calc_uuid'])))
 
     #print(n)
     efermi = 0.2034799610
@@ -384,7 +374,7 @@ def test_fleur_band_remote_Si(with_export_cache, fleur_local_code, create_fleuri
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
 def test_fleur_dos_remote_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,
-                             get_remote_data_si):
+                             get_remote_data_si, show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Calls scf, Several fleur runs needed till convergence
@@ -431,14 +421,12 @@ def test_fleur_dos_remote_Si(with_export_cache, fleur_local_code, create_fleurin
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_banddos_wc_para']
     n = n.get_dict()
-
-    print(get_calcjob_report(orm.load_node(n['last_calc_uuid'])))
 
     #print(n)
     efermi = 0.2034799610

--- a/tests/workflows/test_banddos_workchain.py
+++ b/tests/workflows/test_banddos_workchain.py
@@ -25,7 +25,8 @@ CALC2_ENTRY_POINT = 'fleur.inpgen'
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog, show_workchain_summary):
+def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,
+                                show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Calls scf, Several fleur runs needed till convergence
@@ -92,7 +93,8 @@ def test_fleur_band_fleurinp_Si(with_export_cache, fleur_local_code, create_fleu
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_dos_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog, show_workchain_summary):
+def test_fleur_dos_fleurinp_Si(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,
+                               show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Calls scf, Several fleur runs needed till convergence
@@ -236,7 +238,8 @@ def test_fleur_band_fleurinp_Si_seekpath(with_export_cache, fleur_local_code, cr
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_band_fleurinp_Si_ase(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,show_workchain_summary):
+def test_fleur_band_fleurinp_Si_ase(with_export_cache, fleur_local_code, create_fleurinp, clear_database, aiida_caplog,
+                                    show_workchain_summary):
     """
     Full example using the band dos workchain with just a fleurinp data as input.
     Uses ase bandpath to determine the path through the briloouin zone

--- a/tests/workflows/test_relax_workchain.py
+++ b/tests/workflows/test_relax_workchain.py
@@ -27,7 +27,8 @@ CALC2_ENTRY_POINT = 'fleur.inpgen'
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_relax_fleurinp_Si_bulk(with_export_cache, fleur_local_code, create_fleurinp, clear_database, show_workchain_summary):
+def test_fleur_relax_fleurinp_Si_bulk(with_export_cache, fleur_local_code, create_fleurinp, clear_database,
+                                      show_workchain_summary):
     """
     full example using FleurRelaxWorkChain with just a fleurinp data as input.
     Several fleur runs needed till convergence

--- a/tests/workflows/test_relax_workchain.py
+++ b/tests/workflows/test_relax_workchain.py
@@ -27,7 +27,7 @@ CALC2_ENTRY_POINT = 'fleur.inpgen'
 
 @pytest.mark.regression_test
 @pytest.mark.timeout(500, method='thread')
-def test_fleur_relax_fleurinp_Si_bulk(with_export_cache, fleur_local_code, create_fleurinp, clear_database):
+def test_fleur_relax_fleurinp_Si_bulk(with_export_cache, fleur_local_code, create_fleurinp, clear_database, show_workchain_summary):
     """
     full example using FleurRelaxWorkChain with just a fleurinp data as input.
     Several fleur runs needed till convergence
@@ -58,14 +58,12 @@ def test_fleur_relax_fleurinp_Si_bulk(with_export_cache, fleur_local_code, creat
     #print(out)
     #print(node)
 
-    print(get_workchain_report(node, 'REPORT'))
+    show_workchain_summary(node)
 
     #assert node.is_finished_ok
     # check output
     n = out['output_relax_wc_para']
     n = n.get_dict()
-
-    print(get_workchain_report(orm.load_node(n['last_scf_wc_uuid']), 'REPORT'))
 
     print(n)
     #Dummy checks

--- a/tests/workflows/test_scf_workchain.py
+++ b/tests/workflows/test_scf_workchain.py
@@ -58,8 +58,6 @@ def test_fleur_scf_fleurinp_Si(with_export_cache, fleur_local_code, create_fleur
     n = out['output_scf_wc_para']
     n = n.get_dict()
 
-    print(get_calcjob_report(load_node(n['last_calc_uuid'])))
-
     #print(n)
     assert abs(n.get('distance_charge') - 9.8993e-06) < 2.0e-6
     assert n.get('errors') == []


### PR DESCRIPTION
Branch is based on `support/aiida-2.X`

This introduces a breaking change for the 2.0 version of aiida-fleur. Here we remove uuids from all output dictionaries to enable more consistent caching
Previously any workchain calling multiple FleurScfWorkchains would not be able to be cached