### PR TITLE
CI: Switch from aiida-testing to aiida-test-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,11 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install --upgrade wheel setuptools
-        pip install git+https://github.com/aiidateam/aiida-testing.git@main
+        pip install aiida-test-cache~=0.0.1
         pip install --no-deps git+https://github.com/aiidateam/aiida-common-workflows.git@master
         pip install .[testing,graphs]
         pip install ${{ matrix.aiida.version }} ${{ matrix.masci-tools.version }}
         pip install ${{ matrix.bokeh-version }} ${{ matrix.mpl-version }}
-        reentry scan || true
 
     - name: Run pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
         cache: pip
 
     - name: Install python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: aiida-fleur
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
 
   docs:
@@ -27,20 +30,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.8
-
-    - name: Cache python dependencies
-      id: cache-pip
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: pip-docs-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          pip-docs-
+        cache: pip
 
     - name: Install python dependencies
       run: |
         pip install -e .[docs]
-        reentry scan || true
 
     - name: Build documentation
       env:
@@ -57,19 +51,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache python dependencies
-      id: cache-pip
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: pip-pre-commit-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          pip-pre-commit-
-
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
         python-version: 3.8
+        cache: pip
 
     - name: Install python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         allowed-to-fail: [false]
         include:
           - python-version: "3.11"
-            aiida: {version: 'aiida-core==2.6.3', name: '2.6'}
+            aiida: {version: 'aiida-core==2.3.0', name: '2.3.0'}
             masci-tools: {version: 'masci-tools', name: 'stable'}
             bokeh-version: 'bokeh==3.0.3'
             mpl-version: 'matplotlib==3.6.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         allowed-to-fail: [false]
         include:
           - python-version: "3.11"
-            aiida: {version: 'aiida-core==2.3.0', name: '2.3.0'}
+            aiida: {version: 'aiida-core==2.6.3', name: '2.6'}
             masci-tools: {version: 'masci-tools', name: 'stable'}
             bokeh-version: 'bokeh==3.0.3'
             mpl-version: 'matplotlib==3.6.3'
@@ -167,12 +167,10 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install --upgrade wheel setuptools
-        pip install aiida-test-cache~=0.0.1
         pip install --no-deps git+https://github.com/aiidateam/aiida-common-workflows.git@master
-        pip install .[testing,graphs]
-        pip install ${{ matrix.aiida.version }} ${{ matrix.masci-tools.version }}
-        pip install ${{ matrix.bokeh-version }} ${{ matrix.mpl-version }}
+        pip install -e .[testing,graphs] \
+            ${{ matrix.aiida.version }} ${{ matrix.masci-tools.version }} \
+            ${{ matrix.bokeh-version }} ${{ matrix.mpl-version }}
 
     - name: Run pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,11 @@ docs = [
 testing = [
     "pytest>=2.9",
     "pytest-timeout",
-    "pytest-cov~=3.0",  #For reading configuration from pyproject.toml
+    "pytest-cov~=3.0",
     "pytest-mpl>=0.12",
     "pgtest",
-    "pytest-regressions>=1.0"
+    "pytest-regressions>=1.0",
+    "aiida-test-cache @ git+https://github.com/aiidateam/aiida-testing.git@backport-2.6-support",
     ]
 pre-commit = [
     "pre-commit>=2.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
     "sphinx~=5.0",
     "sphinx_rtd_theme",
     "sphinx-click",
-    "myst-parser~=0.15.2"
+    "myst-parser==0.18.1"
     ]
 testing = [
     "pytest>=2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ testing = [
     "pytest-mpl>=0.12",
     "pgtest",
     "pytest-regressions>=1.0",
-    "aiida-test-cache @ git+https://github.com/aiidateam/aiida-testing.git@backport-2.6-support",
+    "aiida-test-cache==0.0.1",
     ]
 pre-commit = [
     "pre-commit>=2.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ graphs = [
         "masci-tools[bokeh-plots]"
     ]
 docs = [
-    "sphinx~=4.0",
+    "sphinx~=5.0",
     "sphinx_rtd_theme",
     "sphinx-click",
     "myst-parser~=0.15.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,14 +12,14 @@ from pathlib import Path
 
 CONFTEST_LOCATION = Path(__file__).parent.resolve()
 
-# aiida_testing.mock_codes in development, not yet a stable dependency
+# aiida-test-cache package is in development, not yet a stable dependency
 # therefore we try to import it and if it fails we skip tests with it
 
 RUN_REGRESSION_TESTS = True
 try:
-    import aiida_testing
+    import aiida_test_cache
 except ImportError:
-    print('AiiDA-testing not in path. Running without regression tests for Workchains and CalcJobs.')
+    print('aiida-test-cache package not installed. Running without regression tests for Workchains and CalcJobs.')
     RUN_REGRESSION_TESTS = False
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures', 'masci_tools.testing.bokeh']
@@ -36,29 +36,23 @@ def pytest_configure(config):
     We make them all lowercaps as convention
     """
     config.addinivalue_line('markers',
-                            'regression_test: test using the aiida-testing plugin for workflow regression tests')
+                            'regression_test: test using the aiida-test-cache plugin for workflow regression tests')
 
 
 def pytest_collection_modifyitems(session, config, items):
     """After test collection modify collection.
 
-    Skip regression test if aiida-tesing is not there
+    Skip regression tests if aiida-test-cache is not there
     """
     import aiida
 
     skip_regression = pytest.mark.skip(
-        reason='Workflow regression test is skipped, because aiida-testing is not available')
-    # aiida_version_skip = pytest.mark.skipif(
-    #     aiida.get_version().startswith('2.'),
-    #     reason='Workflow regression test is skipped, because aiida-testing is not compatible with AiiDA 2.0')
+        reason='Workflow regression test is skipped, because aiida-test-cache is not available')
 
     regression_items = [item for item in items if 'regression_test' in item.keywords]
     if not RUN_REGRESSION_TESTS:
         for item in regression_items:
             item.add_marker(skip_regression)
-
-    # for item in regression_items:
-    #     item.add_marker(aiida_version_skip)
 
 
 @pytest.fixture(scope='function')
@@ -767,7 +761,7 @@ def load_cache(absolute_archive_path):  # pylint: disable=redefined-outer-name
 
     def _load_cache(archive_path):
         #TODO: private import not good
-        from aiida_testing.archive_cache._utils import load_node_archive  # pylint: disable=import-error
+        from aiida_test_cache.archive_cache._utils import load_node_archive  # pylint: disable=import-error
         full_archive_path = absolute_archive_path(archive_path, overwrite=False)
         # check and load export
         export_exists = os.path.isfile(full_archive_path)


### PR DESCRIPTION
Hi :wave: 

I've been recently updating the the aiida-testing package that you use here for regression tests.

As [part of that work](https://github.com/aiidateam/aiida-test-cache/issues/74), `aiida-testing` pytest plugin has been renamed to `aiida-test-cache` and published on PyPI so you can drop the dependency on Git repo. 
The released version should be fully backwards compatible, see release notes:
https://github.com/aiidateam/aiida-test-cache/releases/tag/v0.0.1