### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
     continue-on-error: ${{ matrix.allow-failure }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-docs-${{ hashFiles('**/pyproject.toml') }}
@@ -55,11 +55,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-pre-commit-${{ hashFiles('**/pyproject.toml') }}
@@ -67,7 +67,7 @@ jobs:
           pip-pre-commit-
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 
@@ -144,11 +144,11 @@ jobs:
         - 5672:5672
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Cache python dependencies
       id: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-${{ matrix.python-version }}-${{ matrix.aiida.name }}-tests-${{ hashFiles('**/pyproject.toml') }}
@@ -156,7 +156,7 @@ jobs:
           pip-${{ matrix.python-version }}-${{ matrix.aiida.name }}-tests
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -184,12 +184,12 @@ jobs:
        ./run_all_cov.sh --local-exe-hdf5
 
     - name: Upload report to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         file: ./tests/coverage.xml
         fail_ci_if_error: False
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: matplotlib-comparison-${{ matrix.python-version }}


### PR DESCRIPTION
Update versions of github actions. This is needed because some versions currently in use are deprecated and will stop to work soon: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/