### PR TITLE
Fix banddos: guard against missing bandgap in SCF results

### DIFF
--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -522,7 +522,7 @@ class FleurBandDosWorkChain(WorkChain):
         # # get efermi from last calculation
         scf_results = None
         efermi_scf = 0
-        bandgap_scf = 0
+        bandgap_scf = None
         if 'remote' in self.inputs:
             scf_results = self.inputs.remote.creator.res
         elif 'scf' in self.inputs:
@@ -531,7 +531,16 @@ class FleurBandDosWorkChain(WorkChain):
 
         if scf_results is not None:
             efermi_scf = scf_results.fermi_energy
-            bandgap_scf = scf_results.bandgap
+            try:
+                bandgap_scf = scf_results.bandgap
+            except AttributeError:
+                # masci-tools outxml_parser only extracts the bandgap for
+                # bz_integration mode 'hist'; with other modes (e.g. 'gauss',
+                # 'tria') the out.xml has no bandgap entry, so accessing it
+                # here raises AttributeError and aborts the whole WorkChain.
+                # None (not 0) keeps the "no data" case distinct from a
+                # metallic (zero-gap) system.
+                bandgap_scf = None
 
         efermi_band = last_calc_out_dict.get('fermi_energy', None)
         bandgap_band = last_calc_out_dict.get('bandgap', None)
@@ -541,7 +550,7 @@ class FleurBandDosWorkChain(WorkChain):
             diff_efermi = efermi_scf - efermi_band
 
         diff_bandgap = None
-        if bandgap_band is not None:
+        if bandgap_band is not None and bandgap_scf is not None:
             diff_bandgap = bandgap_scf - bandgap_band
 
         outputnode_dict = {}


### PR DESCRIPTION
masci-tools' outxml_parser only extracts the bandgap for bz_integration mode 'hist'; with other modes (e.g. 'gauss', 'tria') the out.xml has no bandgap entry. return_results accessed scf_results.bandgap directly, raising AttributeError and aborting the whole WorkChain.

Fall back to None (not 0) when the key is absent, keeping the 'no data' case distinct from a metallic (zero-gap) system, and skip the bandgap difference when either side is missing.