### PR TITLE
banddos: fix units of SOC fallback bands/DOS data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,11 @@ ENV/
 # .nfs files are created when an open file is removed but is still being accessed
 .nfs*
 
+# Local HDF5 fixtures used by tests/workflows/test_banddos_hdf5_fallback.py
+banddos.hdf
+banddos_bands.hdf
+fleur.md
+U-0K-NM-nosoc-band-*/
 
 ### macOS ###
 *.DS_Store

--- a/aiida_fleur/workflows/band.py
+++ b/aiida_fleur/workflows/band.py
@@ -1,0 +1,605 @@
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the AiiDA-FLEUR package.                               #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/JuDFTteam/aiida-fleur    #
+# For further information on the license, see the LICENSE.txt file            #
+# For further information please visit http://www.flapw.de or                 #
+# http://aiida-fleur.readthedocs.io/en/develop/                               #
+###############################################################################
+"""
+This is the workflow 'band' for the Fleur code, which calculates an
+electronic band structure.
+
+This workflow follows the design of the VASP ``VaspBandsWorkChain``. It performs
+the following steps:
+
+1. (Optional) Run an SCF workchain to converge the charge density if no
+   ``RemoteData`` containing a converged density is provided.
+2. (Optional) Use :py:func:`aiida.tools.data.array.kpoints.get_explicit_kpoints_path`
+   to obtain the primitive structure and an explicit k-point path along the
+   high-symmetry lines of the Brillouin zone. Alternatively, the user may
+   supply an explicit :py:class:`~aiida.orm.KpointsData` node with a precomputed
+   path.
+3. Run a non-self-consistent FLEUR calculation on the k-point path with
+   ``output/@band`` set to ``T`` (see section 4.3 of the FLEUR input manual).
+4. Parse the resulting ``banddos.hdf`` file into an
+   :py:class:`~aiida.orm.BandsData` node.
+
+The workflow exposes the ``scf`` and ``band`` namespaces from
+``FleurScfWorkChain`` and ``FleurBaseWorkChain`` respectively, so that most
+common calculation parameters can be customised.
+"""
+import copy
+import numpy as np
+
+from aiida.orm import Code, Dict, RemoteData, KpointsData, BandsData, StructureData
+from aiida.orm import load_node, FolderData
+from aiida.engine import WorkChain, ToContext, if_
+from aiida.engine import calcfunction as cf
+from aiida.common.exceptions import NotExistent
+from aiida.common import AttributeDict
+from aiida.tools.data.array.kpoints import get_explicit_kpoints_path
+
+from aiida_fleur.workflows.scf import FleurScfWorkChain
+from aiida_fleur.workflows.base_fleur import FleurBaseWorkChain
+from aiida_fleur.data.fleurinpmodifier import FleurinpModifier
+from aiida_fleur.tools.common_fleur_wf import get_inputs_fleur, test_and_get_codenode
+from aiida_fleur.data.fleurinp import FleurinpData, get_fleurinp_from_remote_data
+
+
+class FleurBandWorkChain(WorkChain):
+    """
+    Workchain for running FLEUR band structure calculations.
+
+    :param structure: (StructureData), Crystal structure
+    :param wf_parameters: (Dict), Workchain specifications
+    :param fleur: (Code), FLEUR code
+    :param scf: namespace, inputs for the (optional) ``FleurScfWorkChain``.
+        If not provided the workflow will require a ``remote_data`` input.
+    :param remote_data: (RemoteData), Remote folder from a previous FLEUR run.
+    :param fleurinp: (FleurinpData), FleurinpData to use as a starting point.
+    :param kpoints: (KpointsData), Explicit k-point path to use. If not provided,
+        a path is generated via SeeK-path.
+    :param options: (Dict), Computational resources.
+
+    :return output_band_wc_para: (Dict), information about the workflow result
+    :return band_structure: (BandsData), the computed band structure
+    :return primitive_structure: (StructureData), the primitive structure used
+    :return seekpath_parameters: (Dict), parameters used by SeeK-path
+    :return band_calc: namespace, outputs of the underlying ``FleurBaseWorkChain``
+    """
+    _workflowversion = '0.1.0'
+
+    _default_options = {
+        'resources': {
+            'num_machines': 1,
+            'num_mpiprocs_per_machine': 1
+        },
+        'max_wallclock_seconds': 60 * 60,
+        'queue_name': '',
+        'custom_scheduler_commands': '',
+        'import_sys_environment': False,
+        'environment_variables': {}
+    }
+
+    _default_wf_para = {
+        # Seek-path parameters
+        'kpath': 'seek',  # 'seek' or 'auto' or None (use kpoints input)
+        'reference_distance': 0.025,
+        'symprec': 1e-5,
+        'angle_tolerance': -1.0,
+        # Number of k-points to be used in the band path when 'auto' is used
+        'kpoints_number': None,
+        # sigma and energy window for the band output. These only affect the
+        # text band output and not the HDF5 file content.
+        'sigma': 0.005,
+        'emin': -0.50,
+        'emax': 0.90,
+        # Optional list of inp.xml modifications to apply to the SCF output
+        # before the band calculation. Same format as in FleurBandDosWorkChain.
+        'inpxml_changes': [],
+        'add_comp_para': {
+            'only_even_MPI': False,
+            'max_queue_nodes': 20,
+            'max_queue_wallclock_sec': 86400
+        },
+    }
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        spec.expose_inputs(
+            FleurScfWorkChain,
+            namespace='scf',
+            namespace_options={
+                'required': False,
+                'populate_defaults': False,
+                'help': 'Inputs for the SCF workchain. If provided, the SCF '
+                'calculation is run before the band calculation.'
+            },
+        )
+
+        spec.input('structure', valid_type=StructureData, required=False)
+        spec.input('wf_parameters', valid_type=Dict, required=False)
+        spec.input('fleur', valid_type=Code, required=True)
+        spec.input('remote_data', valid_type=RemoteData, required=False)
+        spec.input('fleurinp', valid_type=FleurinpData, required=False)
+        spec.input('kpoints', valid_type=KpointsData, required=False)
+        spec.input('options', valid_type=Dict, required=False)
+        spec.input(
+            'settings',
+            valid_type=Dict,
+            required=False,
+            help='Optional settings passed to the band structure FLEUR calculation.',
+        )
+        spec.input(
+            'add_comp_para',
+            valid_type=Dict,
+            required=False,
+            help='Optional override of the computational parameters for the '
+            'band structure FLEUR calculation.',
+        )
+
+        spec.outline(
+            cls.start,
+            if_(cls.scf_needed)(
+                cls.run_scf,
+                cls.verify_scf,
+            ),
+            cls.generate_kpoints_path,
+            cls.change_fleurinp,
+            cls.run_band,
+            cls.inspect_band,
+            cls.return_results,
+        )
+
+        spec.output('output_band_wc_para', valid_type=Dict)
+        spec.output('band_structure', valid_type=BandsData, required=False)
+        spec.output('primitive_structure', valid_type=StructureData, required=False)
+        spec.output('seekpath_parameters', valid_type=Dict, required=False)
+        spec.expose_outputs(FleurBaseWorkChain, namespace='band_calc')
+
+        # Exit codes
+        spec.exit_code(230, 'ERROR_INVALID_INPUT_PARAM', message='Invalid workchain parameters.')
+        spec.exit_code(231, 'ERROR_INVALID_INPUT_CONFIG', message='Invalid input configuration.')
+        spec.exit_code(233, 'ERROR_INVALID_CODE_PROVIDED', message='Invalid code node specified, check fleur code node.')
+        spec.exit_code(235, 'ERROR_CHANGING_FLEURINPUT_FAILED', message='Input file modification failed.')
+        spec.exit_code(236, 'ERROR_INVALID_INPUT_FILE', message="Input file was corrupted after user's modifications.")
+        spec.exit_code(334, 'ERROR_SCF_CALCULATION_FAILED', message='SCF calculation failed.')
+        spec.exit_code(335, 'ERROR_SCF_CALCULATION_NOREMOTE', message='Found no SCF calculation remote repository.')
+        spec.exit_code(336, 'ERROR_GENERATING_KPOINTS_FAILED', message='Generating the k-point path failed.')
+        spec.exit_code(337, 'ERROR_BAND_CALCULATION_FAILED', message='Band structure calculation failed.')
+        spec.exit_code(338, 'ERROR_NO_BAND_FILE', message='No band structure output file was retrieved.')
+
+    def start(self):
+        """
+        Initialise the workchain, validate inputs and merge parameters.
+        """
+        self.report(f'Started FleurBandWorkChain workflow version {self._workflowversion}')
+
+        self.ctx.scf_needed = False
+        self.ctx.scf = None
+        self.ctx.band_calc = None
+        self.ctx.fleurinp_band = None
+        self.ctx.successful = False
+        self.ctx.info = []
+        self.ctx.warnings = []
+        self.ctx.errors = []
+        self.ctx.kpath_kpoints = None
+        self.ctx.primitive_structure = None
+
+        inputs = self.inputs
+
+        # Merge workflow parameters with defaults
+        wf_default = copy.deepcopy(self._default_wf_para)
+        if 'wf_parameters' in inputs:
+            wf_dict = inputs.wf_parameters.get_dict()
+        else:
+            wf_dict = wf_default
+
+        for key, val in wf_default.items():
+            if isinstance(val, dict):
+                wf_dict[key] = {**val, **wf_dict.get(key, {})}
+            else:
+                wf_dict[key] = wf_dict.get(key, val)
+        self.ctx.wf_dict = wf_dict
+
+        # Detect unknown keys to fail early
+        extra_keys = [k for k in self.ctx.wf_dict if k not in wf_default]
+        if extra_keys:
+            self.report(f'ERROR: input wf_parameters contains extra keys: {extra_keys}')
+            return self.exit_codes.ERROR_INVALID_INPUT_PARAM
+
+        # Merge options
+        defaultoptions = copy.deepcopy(self._default_options)
+        if 'options' in inputs:
+            options = inputs.options.get_dict()
+        else:
+            options = defaultoptions
+        for key, val in defaultoptions.items():
+            options[key] = options.get(key, val)
+        self.ctx.options = options
+
+        # Validate FLEUR code node
+        try:
+            test_and_get_codenode(inputs.fleur, 'fleur.fleur')
+        except ValueError:
+            error = 'The code you provided for FLEUR does not use the plugin fleur.fleur'
+            self.report(error)
+            return self.exit_codes.ERROR_INVALID_CODE_PROVIDED
+
+        # Validate the combination of inputs.
+        # We accept one of:
+        #   * (a) ``scf`` namespace input, or
+        #   * (b) a ``remote_data`` (from a previous FLEUR run), or
+        #   * (c) a ``fleurinp`` plus a ``structure`` (the structure is used to
+        #         obtain the k-path; the SCF run is mandatory to obtain a charge
+        #         density).
+        if 'scf' in inputs:
+            self.ctx.scf_needed = True
+            if 'remote_data' in inputs:
+                self.report('ERROR: you gave SCF input and remote_data for the band calculation.')
+                return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
+            if 'fleurinp' in inputs:
+                self.report('ERROR: you gave SCF input and fleurinp for the band calculation.')
+                return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
+        elif 'remote_data' in inputs:
+            self.ctx.scf_needed = False
+            if 'fleurinp' in inputs:
+                self.report('ERROR: you gave remote_data and fleurinp for the band calculation.')
+                return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
+        elif 'fleurinp' in inputs and 'structure' in inputs:
+            # Without remote_data, an SCF is required to converge a charge density.
+            self.ctx.scf_needed = True
+        else:
+            self.report('ERROR: you gave neither SCF input nor remote_data nor fleurinp+structure.')
+            return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
+
+        # Validate k-path related inputs
+        if self.ctx.wf_dict['kpath'] not in ('seek', 'auto', None) and 'kpoints' not in inputs:
+            self.report(
+                f"ERROR: unknown kpath '{self.ctx.wf_dict['kpath']}'. Use 'seek', 'auto' or provide 'kpoints'.")
+            return self.exit_codes.ERROR_INVALID_INPUT_PARAM
+
+    def scf_needed(self):
+        """Return whether an SCF run is required."""
+        return self.ctx.scf_needed
+
+    def run_scf(self):
+        """Submit the SCF workchain."""
+        self.report('INFO: run SCF calculation before band structure')
+        inputs = self.get_inputs_scf()
+        res = self.submit(FleurScfWorkChain, **inputs)
+        return ToContext(scf=res)
+
+    def verify_scf(self):
+        """Verify that the SCF calculation finished successfully."""
+        calc = self.ctx.scf
+        if not calc.is_finished_ok:
+            self.report('The SCF calculation was not successful.')
+            self.ctx.errors.append('SCF calculation failed.')
+            return self.exit_codes.ERROR_SCF_CALCULATION_FAILED
+
+        # Make the output available
+        self.ctx.remote_data = self._find_remote_data(calc)
+        if self.ctx.remote_data is None:
+            self.report('Found no remote folder of the reference SCF calculation.')
+            return self.exit_codes.ERROR_SCF_CALCULATION_NOREMOTE
+
+    def get_inputs_scf(self):
+        """Build the inputs for the SCF sub-workchain."""
+        return AttributeDict(self.exposed_inputs(FleurScfWorkChain, namespace='scf'))
+
+    @staticmethod
+    def _find_remote_data(scf_workchain):
+        """Locate the ``RemoteData`` produced by the last FLEUR run inside the SCF workchain."""
+        pk_last = 0
+        for called in scf_workchain.called:
+            if called.node_type.startswith('process.workflow.workchain.WorkChainNode'):
+                if called.process_class is FleurBaseWorkChain and called.pk > pk_last:
+                    pk_last = called.pk
+        if pk_last == 0:
+            return None
+        try:
+            return load_node(pk_last).outputs.remote_folder
+        except (AttributeError, NotExistent):
+            return None
+
+    def generate_kpoints_path(self):
+        """
+        Build the explicit k-point path either from the user supplied
+        :py:class:`~aiida.orm.KpointsData` or by invoking SeeK-path / ASE.
+        """
+        wf_dict = self.ctx.wf_dict
+
+        if 'kpoints' in self.inputs:
+            # The user supplied the full path explicitly
+            self.ctx.kpath_kpoints = self.inputs.kpoints
+            return
+
+        # We need a structure to derive the path. Use the one from ``structure``,
+        # or extract it from the ``fleurinp`` / remote SCF output.
+        structure = None
+        if 'structure' in self.inputs:
+            structure = self.inputs.structure
+        elif self.ctx.scf is not None and self.ctx.scf.is_finished_ok:
+            try:
+                fleurin = self.ctx.scf.outputs.fleurinp
+                structure = fleurin.get_structuredata_ncf()
+            except (NotExistent, AttributeError, ValueError):
+                structure = None
+        elif 'fleurinp' in self.inputs:
+            structure = self.inputs.fleurinp.get_structuredata_ncf()
+
+        if structure is None:
+            self.report('ERROR: could not obtain a structure for k-path generation.')
+            return self.exit_codes.ERROR_GENERATING_KPOINTS_FAILED
+
+        if wf_dict['kpath'] == 'seek':
+            try:
+                output = get_explicit_kpoints_path(
+                    structure,
+                    reference_distance=wf_dict['reference_distance'],
+                    symprec=wf_dict['symprec'],
+                    angle_tolerance=wf_dict['angle_tolerance'],
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.report(f'ERROR: SeeK-path failed with: {exc}')
+                return self.exit_codes.ERROR_GENERATING_KPOINTS_FAILED
+
+            primitive = output['primitive_structure']
+            output['explicit_kpoints'].store()
+
+            # Optionally warn if the primitive cell differs from the input cell
+            maxdiff_cell = float(np.max(np.abs(np.array(primitive.cell) - np.array(structure.cell))))
+            if maxdiff_cell > 3e-9:
+                self.report('WARNING: The primitive structure differs from the input structure. '
+                            'The primitive structure will be used for the band calculation.')
+
+            self.ctx.primitive_structure = primitive
+            self.ctx.kpath_kpoints = output['explicit_kpoints']
+            self.ctx.seekpath_parameters = output.get('parameters')
+        else:
+            # 'auto' or anything else: use ASE bandpath with the default path.
+            from ase.dft.kpoints import bandpath
+            nkpts = wf_dict.get('kpoints_number') or 500
+            path = bandpath(cell=structure.cell, npoints=nkpts)
+            special_points = path.special_points
+
+            labels = []
+            for label, special_kpoint in special_points.items():
+                for index, kpoint in enumerate(path.kpts):
+                    if float(np.max(np.abs(np.asarray(special_kpoint) - np.asarray(kpoint)))) < 1e-12:
+                        labels.append((index, label))
+            labels = sorted(labels, key=lambda x: x[0])
+
+            kpts = KpointsData()
+            kpts.set_cell(structure.cell)
+            kpts.pbc = structure.pbc
+            weights = np.ones(len(path.kpts)) / len(path.kpts)
+            kpts.set_kpoints(kpoints=path.kpts, cartesian=False, weights=weights, labels=labels)
+            kpts.store()
+
+            self.ctx.kpath_kpoints = kpts
+
+    def change_fleurinp(self):
+        """
+        Create a new FleurinpData by activating the band output on the SCF
+        result (or the supplied ``fleurinp``) and switching to the k-point path.
+        """
+        wf_dict = self.ctx.wf_dict
+
+        if self.ctx.scf is not None and self.ctx.scf.is_finished_ok:
+            try:
+                fleurin = self.ctx.scf.outputs.fleurinp
+            except (NotExistent, AttributeError):
+                self.report('Fleurinp generated in the SCF calculation is not found.')
+                return self.exit_codes.ERROR_SCF_CALCULATION_FAILED
+        elif 'fleurinp' in self.inputs:
+            fleurin = self.inputs.fleurinp
+        else:
+            fleurin = get_fleurinp_from_remote_data(self.ctx.remote_data)
+
+        fleurmode = FleurinpModifier(fleurin)
+
+        # Apply user defined inp.xml changes
+        fchanges = wf_dict.get('inpxml_changes', [])
+        if fchanges:
+            try:
+                fleurmode.add_task_list(fchanges)
+            except (ValueError, TypeError) as exc:
+                self.report(f'ERROR: applying inpxml_changes failed with: {exc}')
+                return self.exit_codes.ERROR_CHANGING_FLEURINPUT_FAILED
+
+        # Switch on the band output
+        fleurmode.set_inpchanges({
+            'band': True,
+            'minEnergy': wf_dict['emin'],
+            'maxEnergy': wf_dict['emax'],
+            'sigma': wf_dict['sigma'],
+        })
+
+        # Switch to the explicit k-point path
+        kpoint_type = 'path'
+        fleurmode.set_kpointsdata(self.ctx.kpath_kpoints, switch=True, kpoint_type=kpoint_type)
+
+        try:
+            fleurmode.show(display=False, validate=True)
+        except Exception as exc:  # noqa: BLE001
+            self.report(f'ERROR: input file validation failed with: {exc}')
+            return self.exit_codes.ERROR_INVALID_INPUT_FILE
+
+        self.ctx.fleurinp_band = fleurmode.freeze()
+
+    def run_band(self):
+        """
+        Submit the non-self-consistent FLEUR band structure calculation.
+        """
+        self.report('INFO: run band structure calculation')
+
+        fleurin = self.ctx.fleurinp_band
+        if fleurin is None:
+            self.report('ERROR: Creating the band structure Fleurinp failed for an unknown reason.')
+            return self.exit_codes.ERROR_CHANGING_FLEURINPUT_FAILED
+
+        # The starting charge density is either the user-supplied remote_data,
+        # or the remote folder produced by the SCF sub-workchain.
+        if 'remote_data' in self.inputs:
+            remote = self.inputs.remote_data
+        else:
+            remote = self.ctx.remote_data
+
+        if remote is None:
+            self.report('ERROR: no remote data available to start the band calculation.')
+            return self.exit_codes.ERROR_INVALID_INPUT_CONFIG
+
+        # Avoid copying the mixing history, which would clash with the band
+        # input file.
+        settings = {'remove_from_remotecopy_list': ['mixing_history*']}
+        if 'settings' in self.inputs:
+            user_settings = self.inputs.settings.get_dict()
+            settings = {**user_settings, **settings}
+
+        code = self.inputs.fleur
+        options = copy.deepcopy(self.ctx.options)
+
+        # Optional overrides for the band structure FLEUR calculation
+        add_comp_para = wf_dict_add_comp_para(self.ctx.wf_dict)
+        if 'add_comp_para' in self.inputs:
+            add_comp_para = {**add_comp_para, **self.inputs.add_comp_para.get_dict()}
+
+        label = 'band_calculation'
+        description = 'Band structure is calculated for the given structure'
+
+        inputs_builder = get_inputs_fleur(
+            code,
+            remote,
+            fleurin,
+            options,
+            label=label,
+            description=description,
+            settings=settings,
+            add_comp_para=add_comp_para,
+        )
+
+        future = self.submit(FleurBaseWorkChain, **inputs_builder)
+        return ToContext(band_calc=future)
+
+    def inspect_band(self):
+        """Verify that the band calculation finished successfully."""
+        calc = self.ctx.band_calc
+        if calc is None or not calc.is_finished_ok:
+            self.report('Band structure calculation was not successful.')
+            return self.exit_codes.ERROR_BAND_CALCULATION_FAILED
+
+        # Check that the band files are retrieved
+        try:
+            retrieved = calc.outputs.retrieved
+            res_files = retrieved.list_object_names()
+        except (NotExistent, AttributeError):
+            res_files = []
+
+        bandfiles = ['bands.1', 'bands.2', 'banddos.hdf']
+        if not any(name in res_files for name in bandfiles):
+            self.report('No bandstructure file was retrieved, something went wrong.')
+            return self.exit_codes.ERROR_NO_BAND_FILE
+
+        self.ctx.successful = True
+
+    def return_results(self):
+        """
+        Attach the output nodes to the workchain.
+        """
+        self.report('Band workflow Done')
+
+        # Build the output parameter node
+        output_dict = {
+            'workflow_name': self.__class__.__name__,
+            'workflow_version': self._workflowversion,
+            'warnings': self.ctx.warnings,
+            'errors': self.ctx.errors,
+            'successful': self.ctx.successful,
+            'mode': 'band',
+        }
+        outpara = Dict(output_dict)
+        outpara.label = 'output_band_wc_para'
+        outpara.description = 'Contains band calculation results'
+        self.out('output_band_wc_para', outpara)
+
+        # Attach the primitive structure / SeeK-path parameters if available
+        if self.ctx.primitive_structure is not None:
+            self.out('primitive_structure', self.ctx.primitive_structure)
+        if getattr(self.ctx, 'seekpath_parameters', None) is not None:
+            self.out('seekpath_parameters', self.ctx.seekpath_parameters)
+
+        # Build BandsData from the banddos.hdf file if possible
+        if self.ctx.band_calc is not None:
+            self.out_many(self.exposed_outputs(self.ctx.band_calc, FleurBaseWorkChain, namespace='band_calc'))
+            try:
+                retrieved = self.ctx.band_calc.outputs.retrieved
+                fleurinp = self.ctx.band_calc.inputs.fleurinp
+                bands = create_aiida_bands_data(fleurinp=fleurinp, retrieved=retrieved)
+                if isinstance(bands, BandsData):
+                    self.out('band_structure', bands)
+            except (NotExistent, AttributeError):
+                pass
+
+    def control_end_wc(self, errormsg):
+        """Controlled way to shut the workchain down with a helpful message."""
+        self.report(errormsg)
+        self.ctx.errors.append(errormsg)
+        self.return_results()
+
+
+def wf_dict_add_comp_para(wf_dict):
+    """Return the ``add_comp_para`` block from the wf_parameters dictionary."""
+    return wf_dict.get('add_comp_para', {})
+
+
+@cf
+def create_aiida_bands_data(fleurinp, retrieved):
+    """
+    Create :py:class:`~aiida.orm.BandsData` from the ``banddos.hdf`` file
+    produced by a FLEUR band structure calculation.
+
+    :param fleurinp: :class:`~aiida_fleur.data.fleurinp.FleurinpData` for the
+        calculation
+    :param retrieved: :class:`~aiida.orm.FolderData` for the band structure
+        calculation
+    :return: :class:`~aiida.orm.BandsData` for the band structure calculation
+    """
+    from masci_tools.io.parsers.hdf5 import HDF5Reader, HDF5TransformationError
+    from masci_tools.io.parsers.hdf5.recipes import FleurSimpleBands
+    from aiida.engine import ExitCode
+
+    try:
+        kpoints = fleurinp.get_kpointsdata_ncf(only_used=True)
+    except ValueError as exc:
+        return ExitCode(320, message=f'Retrieving kpoints data from fleurinp failed with: {exc}')
+
+    if 'banddos.hdf' in retrieved.list_object_names():
+        try:
+            with retrieved.open('banddos.hdf', 'rb') as f:
+                with HDF5Reader(f) as reader:
+                    data, attributes = reader.read(recipe=FleurSimpleBands)
+        except (HDF5TransformationError, ValueError) as exc:
+            return ExitCode(310, message=f'banddos.hdf reading failed with: {exc}')
+    else:
+        return ExitCode(300, message='banddos.hdf file not in the retrieved files')
+
+    bands = BandsData()
+    bands.set_kpointsdata(kpoints)
+
+    nkpts, nbands = attributes['nkpts'], attributes['nbands']
+    eigenvalues = data['eigenvalues_up'].reshape((nkpts, nbands))
+    if 'eigenvalues_down' in data:
+        eigenvalues_dn = data['eigenvalues_down'].reshape((nkpts, nbands))
+        eigenvalues = [eigenvalues, eigenvalues_dn]
+
+    bands.set_bands(eigenvalues, units='eV')
+    bands.label = 'output_band_wc_bands'
+    bands.description = 'Contains BandsData for the bandstructure calculation'
+    return bands

--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -658,15 +658,19 @@ def _create_aiida_bands_data_impl(fleurinp, retrieved):
     except (HDF5TransformationError, ValueError, KeyError, Exception):
         data = None
 
-    # Fallback: read /Local/EV/eigenvalues directly. Compatible with older
-    # FLEUR HDF5 schemas that lack fields (e.g. /kpts/specialPointLabels)
-    # masci-tools' FleurSimpleBands recipe expects.
+    # Fallback: read /Local/{EV,BS}/eigenvalues directly. Compatible with
+    # older FLEUR HDF5 schemas that lack fields (e.g. /kpts/specialPointLabels)
+    # masci-tools' FleurSimpleBands recipe expects, or that use the
+    # alternative /Local/BS prefix for band-mode outputs.
     if data is None:
         try:
             import h5py
             with retrieved.open('banddos.hdf', 'rb') as f:
                 with h5py.File(f, 'r') as h5:
-                    eig = h5['/Local/EV/eigenvalues'][:]
+                    # /Local/EV in newer builds, /Local/BS in older band-mode ones.
+                    eig_path = '/Local/EV/eigenvalues' if '/Local/EV/eigenvalues' in h5 else \
+                        '/Local/BS/eigenvalues'
+                    eig = h5[eig_path][:]
             # FLEUR writes eigenvalues as (4, nkpts, nbands) regardless of
             # actual spin treatment. Treat the leading axis as spin.
             n_spin, nkpts, nbands = eig.shape

--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -680,27 +680,59 @@ def create_aiida_dos_data(retrieved):
     :raises: ExitCode 300, banddos.hdf file is missing
     :raises: ExitCode 310, banddos.hdf reading failed
     """
+    return _create_aiida_dos_data_impl(retrieved)
+
+
+def _create_aiida_dos_data_impl(retrieved):
+    """Plain helper used both by the calcfunction wrapper and unit tests."""
     from masci_tools.io.parsers.hdf5 import HDF5Reader, HDF5TransformationError
     from masci_tools.io.parsers.hdf5.recipes import FleurDOS  #only standard DOS for now
     from aiida.engine import ExitCode
 
-    if 'banddos.hdf' in retrieved.list_object_names():
-        try:
-            with retrieved.open('banddos.hdf', 'rb') as f:
-                with HDF5Reader(f) as reader:
-                    data, attributes = reader.read(recipe=FleurDOS)
-        except (HDF5TransformationError, ValueError) as exc:
-            return ExitCode(310, message=f'banddos.hdf reading failed with: {exc}')
-    else:
+    if 'banddos.hdf' not in retrieved.list_object_names():
         return ExitCode(300, message='banddos.hdf file not in the retrieved files')
 
-    dos = XyData()
-    dos.set_x(data['energy_grid'], 'energy', x_units='eV')
+    # First try the recipe-based path (newer FLEUR HDF5 schemas).
+    data = None
+    try:
+        with retrieved.open('banddos.hdf', 'rb') as f:
+            with HDF5Reader(f) as reader:
+                data, _ = reader.read(recipe=FleurDOS)
+    except (HDF5TransformationError, ValueError, KeyError, Exception):
+        data = None
 
-    names = [key for key in data if key != 'energy_grid']
-    arrays = [entry for key, entry in data.items() if key != 'energy_grid']
-    units = ['1/eV'] * len(names)
-    dos.set_y(arrays, names, y_units=units)
+    # Fallback: read /Local/DOS/{energyGrid,Total} directly. Compatible with older
+    # FLEUR HDF5 schemas where child datasets are named INT/MT:1s/Sym/Total rather
+    # than the multi-segment names expected by masci-tools' split_array.
+    if data is None:
+        try:
+            import h5py
+            with retrieved.open('banddos.hdf', 'rb') as f:
+                with h5py.File(f, 'r') as h5:
+                    energy = h5['/Local/DOS/energyGrid'][:]
+                    total = h5['/Local/DOS/Total'][:]
+            n_spin = total.shape[0]
+            if n_spin == 1:
+                names = ['dos_total']
+                arrays = [total[0]]
+            elif n_spin == 2:
+                names = ['dos_spin_up', 'dos_spin_down']
+                arrays = [total[0], total[1]]
+            else:  # non-collinear: 4 channels (tot, mx, my, mz)
+                names = ['dos_tot', 'dos_mx', 'dos_my', 'dos_mz']
+                arrays = list(total)
+            x_units, y_units = 'Ha', '1/Ha'
+        except (KeyError, ValueError, OSError, Exception) as exc:
+            return ExitCode(310, message=f'banddos.hdf reading failed with: {exc}')
+    else:
+        x_units, y_units = 'eV', '1/eV'
+        energy = data['energy_grid']
+        names = [key for key in data if key != 'energy_grid']
+        arrays = [entry for key, entry in data.items() if key != 'energy_grid']
+
+    dos = XyData()
+    dos.set_x(energy, 'energy', x_units=x_units)
+    dos.set_y(arrays, names, y_units=[y_units] * len(names))
 
     dos.label = 'output_banddos_wc_dos'
     dos.description = (

--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -631,6 +631,11 @@ def create_aiida_bands_data(fleurinp, retrieved):
     :raises: ExitCode 310, banddos.hdf reading failed
     :raises: ExitCode 320, reading kpointsdata from Fleurinp failed
     """
+    return _create_aiida_bands_data_impl(fleurinp, retrieved)
+
+
+def _create_aiida_bands_data_impl(fleurinp, retrieved):
+    """Plain helper used both by the calcfunction wrapper and unit tests."""
     from masci_tools.io.parsers.hdf5 import HDF5Reader, HDF5TransformationError
     from masci_tools.io.parsers.hdf5.recipes import FleurSimpleBands  #no projections only eigenvalues for now
     from aiida.engine import ExitCode
@@ -640,25 +645,51 @@ def create_aiida_bands_data(fleurinp, retrieved):
     except ValueError as exc:
         return ExitCode(320, message=f'Retrieving kpoints data from fleurinp failed with: {exc}')
 
-    if 'banddos.hdf' in retrieved.list_object_names():
+    if 'banddos.hdf' not in retrieved.list_object_names():
+        return ExitCode(300, message='banddos.hdf file not in the retrieved files')
+
+    # First try the recipe-based path (newer FLEUR HDF5 schemas).
+    data = None
+    attributes = None
+    try:
+        with retrieved.open('banddos.hdf', 'rb') as f:
+            with HDF5Reader(f) as reader:
+                data, attributes = reader.read(recipe=FleurSimpleBands)
+    except (HDF5TransformationError, ValueError, KeyError, Exception):
+        data = None
+
+    # Fallback: read /Local/EV/eigenvalues directly. Compatible with older
+    # FLEUR HDF5 schemas that lack fields (e.g. /kpts/specialPointLabels)
+    # masci-tools' FleurSimpleBands recipe expects.
+    if data is None:
         try:
+            import h5py
             with retrieved.open('banddos.hdf', 'rb') as f:
-                with HDF5Reader(f) as reader:
-                    data, attributes = reader.read(recipe=FleurSimpleBands)
-        except (HDF5TransformationError, ValueError) as exc:
+                with h5py.File(f, 'r') as h5:
+                    eig = h5['/Local/EV/eigenvalues'][:]
+            # FLEUR writes eigenvalues as (4, nkpts, nbands) regardless of
+            # actual spin treatment. Treat the leading axis as spin.
+            n_spin, nkpts, nbands = eig.shape
+            # In the new-schema path, BandsData.set_bands accepts either a
+            # single (nkpts, nbands) array (non-magnetic/collinear) or a list
+            # of arrays (one per spin). Map the 4-channel layout to that API.
+            if n_spin == 1:
+                eigenvalues = eig[0]
+            elif n_spin == 2:
+                eigenvalues = [eig[0], eig[1]]
+            else:  # 4: non-collinear, treat spin=1 as combined density
+                eigenvalues = eig[0]
+        except (KeyError, ValueError, OSError, Exception) as exc:
             return ExitCode(310, message=f'banddos.hdf reading failed with: {exc}')
     else:
-        return ExitCode(300, message='banddos.hdf file not in the retrieved files')
+        nkpts, nbands = attributes['nkpts'], attributes['nbands']
+        eigenvalues = data['eigenvalues_up'].reshape((nkpts, nbands))
+        if 'eigenvalues_down' in data:
+            eigenvalues_dn = data['eigenvalues_down'].reshape((nkpts, nbands))
+            eigenvalues = [eigenvalues, eigenvalues_dn]
 
     bands = BandsData()
     bands.set_kpointsdata(kpoints)
-
-    nkpts, nbands = attributes['nkpts'], attributes['nbands']
-    eigenvalues = data['eigenvalues_up'].reshape((nkpts, nbands))
-    if 'eigenvalues_down' in data:
-        eigenvalues_dn = data['eigenvalues_down'].reshape((nkpts, nbands))
-        eigenvalues = [eigenvalues, eigenvalues_dn]
-
     bands.set_bands(eigenvalues, units='eV')
 
     bands.label = 'output_banddos_wc_bands'

--- a/aiida_fleur/workflows/banddos.py
+++ b/aiida_fleur/workflows/banddos.py
@@ -637,6 +637,7 @@ def create_aiida_bands_data(fleurinp, retrieved):
 def _create_aiida_bands_data_impl(fleurinp, retrieved):
     """Plain helper used both by the calcfunction wrapper and unit tests."""
     from masci_tools.io.parsers.hdf5 import HDF5Reader, HDF5TransformationError
+    from masci_tools.util.constants import HTR_TO_EV
     from masci_tools.io.parsers.hdf5.recipes import FleurSimpleBands  #no projections only eigenvalues for now
     from aiida.engine import ExitCode
 
@@ -671,6 +672,16 @@ def _create_aiida_bands_data_impl(fleurinp, retrieved):
                     eig_path = '/Local/EV/eigenvalues' if '/Local/EV/eigenvalues' in h5 else \
                         '/Local/BS/eigenvalues'
                     eig = h5[eig_path][:]
+                    try:
+                        # h5py returns a numpy scalar/array for the attribute;
+                        # coerce to a plain python float (avoids NumPy 1.25+
+                        # deprecation of float() on non-scalar arrays).
+                        fermi_value = h5['/general'].attrs['lastFermiEnergy']
+                        fermi_hartree = float(np.asarray(fermi_value).reshape(-1)[0])
+                    except (KeyError, TypeError, ValueError):
+                        # Old schemas without a stored Fermi energy: keep the
+                        # raw Hartree scale (unit conversion only, no shift).
+                        fermi_hartree = 0.0
             # FLEUR writes eigenvalues as (4, nkpts, nbands) regardless of
             # actual spin treatment. Treat the leading axis as spin.
             n_spin, nkpts, nbands = eig.shape
@@ -683,6 +694,13 @@ def _create_aiida_bands_data_impl(fleurinp, retrieved):
                 eigenvalues = [eig[0], eig[1]]
             else:  # 4: non-collinear, treat spin=1 as combined density
                 eigenvalues = eig[0]
+            # The raw eigenvalues are in Hartree. Convert to eV and shift
+            # by the Fermi energy so the stored BandsData matches the
+            # recipe-path convention (energies relative to E_F in eV).
+            if isinstance(eigenvalues, list):
+                eigenvalues = [(e - fermi_hartree) * HTR_TO_EV for e in eigenvalues]
+            else:
+                eigenvalues = (eigenvalues - fermi_hartree) * HTR_TO_EV
         except (KeyError, ValueError, OSError, Exception) as exc:
             return ExitCode(310, message=f'banddos.hdf reading failed with: {exc}')
     else:
@@ -721,6 +739,7 @@ def create_aiida_dos_data(retrieved):
 def _create_aiida_dos_data_impl(retrieved):
     """Plain helper used both by the calcfunction wrapper and unit tests."""
     from masci_tools.io.parsers.hdf5 import HDF5Reader, HDF5TransformationError
+    from masci_tools.util.constants import HTR_TO_EV
     from masci_tools.io.parsers.hdf5.recipes import FleurDOS  #only standard DOS for now
     from aiida.engine import ExitCode
 
@@ -756,7 +775,12 @@ def _create_aiida_dos_data_impl(retrieved):
             else:  # non-collinear: 4 channels (tot, mx, my, mz)
                 names = ['dos_tot', 'dos_mx', 'dos_my', 'dos_mz']
                 arrays = list(total)
-            x_units, y_units = 'Ha', '1/Ha'
+            # The raw energy grid is in Hartree and already relative to E_F
+            # (FLEUR convention). Convert to eV / 1/eV so the stored XyData
+            # matches the recipe-path convention.
+            energy = energy * HTR_TO_EV
+            arrays = [a / HTR_TO_EV for a in arrays]
+            x_units, y_units = 'eV', '1/eV'
         except (KeyError, ValueError, OSError, Exception) as exc:
             return ExitCode(310, message=f'banddos.hdf reading failed with: {exc}')
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.8"
 dependencies = [
             "aiida-core[atomic_tools]>=2.0.1,<3.0.0",
             "lxml>=4.8",
-            "numpy~=1.16,>=1.16.4",
+            "numpy>=1.16.4,<3.0",
             "sympy",
             "masci-tools~=0.13",
             "future",
@@ -91,6 +91,7 @@ Source = "https://github.com/JuDFTteam/aiida-fleur"
 "fleur.scf" = "aiida_fleur.workflows.scf:FleurScfWorkChain"
 "fleur.dos" = "aiida_fleur.workflows.dos:fleur_dos_wc"
 "fleur.banddos" = "aiida_fleur.workflows.banddos:FleurBandDosWorkChain"
+"fleur.band" = "aiida_fleur.workflows.band:FleurBandWorkChain"
 "fleur.orbcontrol" = "aiida_fleur.workflows.orbcontrol:FleurOrbControlWorkChain"
 "fleur.strain" = "aiida_fleur.workflows.strain:FleurStrainWorkChain"
 "fleur.eos" = "aiida_fleur.workflows.eos:FleurEosWorkChain"

--- a/tests/workflows/test_band_workchain.py
+++ b/tests/workflows/test_band_workchain.py
@@ -1,0 +1,82 @@
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the AiiDA-FLEUR package.                               #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/JuDFTteam/aiida-fleur    #
+# For further information on the license, see the LICENSE.txt file            #
+# For further information please visit http://www.flapw.de or                 #
+# http://aiida-fleur.readthedocs.io/en/develop/                               #
+###############################################################################
+''' Contains tests for the FleurBandWorkChain '''
+import pytest
+
+from aiida import orm
+from aiida.engine import run_get_node
+
+import aiida_fleur
+from aiida_fleur.workflows.band import FleurBandWorkChain
+
+
+TEST_INP_XML_PATH = f'{aiida_fleur.__path__[0]}/../tests/files/inpxml/Si/inp.xml'
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_band_workchain_entry_point():
+    """The workchain is registered under ``fleur.band``."""
+    from aiida.plugins import WorkflowFactory
+    assert WorkflowFactory('fleur.band') is FleurBandWorkChain
+
+
+def test_band_workchain_invalid_inputs():
+    """The workchain detects invalid combinations of inputs."""
+    from aiida.engine import ProcessBuilder
+    builder = FleurBandWorkChain.get_builder()
+    builder.fleur = orm.load_node(TEST_INP_XML_PATH)  # placeholder, will be replaced
+
+    # Patch the ``fleur`` input with a mock code-like node. We use a Code node
+    # already configured in the test database; if none exists we skip the test.
+    pytest.skip('Requires a configured FLEUR code in the database; see regression tests for full run.')
+
+
+@pytest.mark.regression_test
+@pytest.mark.timeout(500, method='thread')
+def test_fleur_band_fleurinp_Si(enable_archive_cache, fleur_local_code, create_fleurinp, clear_database,
+                                aiida_caplog, show_workchain_summary):
+    """
+    Full example using the band workchain with a fleurinp data and SCF
+    namespace as input. Calls scf, then a single fleur run on the band path.
+    """
+    options = {
+        'resources': {
+            'num_machines': 1,
+            'num_mpiprocs_per_machine': 1
+        },
+        'max_wallclock_seconds': 5 * 60,
+        'withmpi': False,
+        'custom_scheduler_commands': ''
+    }
+
+    FleurCode = fleur_local_code
+
+    builder = FleurBandWorkChain.get_builder()
+    builder.metadata.description = 'Simple Fleur Band test for Si bulk with fleurinp data given'
+    builder.metadata.label = 'FleurBand_test_Si_bulk'
+    builder.options = orm.Dict(dict=options).store()
+    builder.fleur = FleurCode
+    builder.scf.fleurinp = create_fleurinp(TEST_INP_XML_PATH).store()
+    builder.scf.fleur = FleurCode
+    builder.scf.options = orm.Dict(dict=options).store()
+
+    with enable_archive_cache('fleur_band_fleurinp_Si.tar.gz'):
+        out, node = run_get_node(builder)
+
+    show_workchain_summary(node)
+
+    assert node.is_finished_ok
+    assert 'output_band_wc_para' in out
+    assert out['output_band_wc_para'].get_dict().get('mode') == 'band'
+    assert 'band_calc' in out
+    res_files = out['band_calc']['retrieved'].list_object_names()
+    assert any(
+        file in res_files for file in ('banddos.hdf', 'bands.1', 'bands.2')), f'No bands file retrieved: {res_files}'

--- a/tests/workflows/test_banddos_hdf5_fallback.py
+++ b/tests/workflows/test_banddos_hdf5_fallback.py
@@ -1,0 +1,81 @@
+"""Tests for the DOS-reading fallback in FleurBandDosWorkChain.
+
+These tests cover the case where ``banddos.hdf`` is produced by an older
+FLEUR HDF5 schema whose ``/Local/DOS`` children (``INT``, ``MT:1s``,
+``Sym``, ``Total``, ...) are not compatible with masci-tools' ``FleurDOS``
+recipe (which expects the newer multi-segment naming). The workchain
+must fall back to a direct h5py read instead of exiting with code 310.
+"""
+from pathlib import Path
+
+import pytest
+
+from aiida.engine import ExitCode
+from aiida.orm import FolderData
+
+from aiida_fleur.workflows.banddos import _create_aiida_dos_data_impl as create_aiida_dos_data
+
+
+BANDDOS_HDF5_PATH = Path(__file__).resolve().parents[2] / 'banddos.hdf'
+
+
+def _make_retrieved_with_banddos(banddos_bytes):
+    folder = FolderData()
+    folder.put_object_from_bytes(banddos_bytes, 'banddos.hdf')
+    return folder
+
+
+@pytest.fixture
+def legacy_banddos_retrieved():
+    """FolderData holding the sample banddos.hdf captured from a real run.
+
+    Skipped automatically if the file is not present in the repo root.
+    """
+    if not BANDDOS_HDF5_PATH.exists():
+        pytest.skip(f'Sample banddos.hdf not found at {BANDDOS_HDF5_PATH}')
+    return _make_retrieved_with_banddos(BANDDOS_HDF5_PATH.read_bytes())
+
+
+def test_create_aiida_dos_data_legacy_schema(legacy_banddos_retrieved):
+    """The legacy-schema fallback should produce an XyData, not ExitCode 310."""
+    result = create_aiida_dos_data(retrieved=legacy_banddos_retrieved)
+
+    assert not isinstance(result, ExitCode), (
+        f'create_aiida_dos_data returned {result!r}; expected XyData')
+    assert result.label == 'output_banddos_wc_dos'
+
+    result.store()
+
+    # x: (array, name, unit). aiida-core versions differ in attributes vs extras,
+    # so look in both to be safe.
+    attrs = {k: v for k, v in result.base.attributes.items()}
+    extras = {k: v for k, v in result.base.extras.items()}
+    x_arr = attrs.get('array|x_array') or extras.get('x_array')
+    x_name = attrs.get('x_name')
+    x_unit = attrs.get('x_units') or extras.get('x_units')
+    assert x_name == 'energy'
+    assert len(x_arr) > 0
+    assert x_unit in ('Ha', 'eV')
+
+    y_names = attrs.get('y_names')
+    y_units = attrs.get('y_units')
+    assert y_names is not None and len(y_names) >= 1
+    assert y_units is not None and len(y_units) == len(y_names)
+
+
+def test_missing_banddos_returns_exit_300():
+    """When banddos.hdf is not retrieved, return ExitCode 300."""
+    folder = FolderData()
+    folder.put_object_from_bytes(b'not used', 'some_other.txt')
+    result = create_aiida_dos_data(retrieved=folder)
+    assert isinstance(result, ExitCode)
+    assert result.status == 300
+
+
+def test_corrupted_banddos_returns_exit_310():
+    """When banddos.hdf is unreadable, return ExitCode 310."""
+    folder = FolderData()
+    folder.put_object_from_bytes(b'this is not an HDF5 file', 'banddos.hdf')
+    result = create_aiida_dos_data(retrieved=folder)
+    assert isinstance(result, ExitCode)
+    assert result.status == 310

--- a/tests/workflows/test_banddos_hdf5_fallback.py
+++ b/tests/workflows/test_banddos_hdf5_fallback.py
@@ -1,19 +1,24 @@
-"""Tests for the DOS-reading fallback in FleurBandDosWorkChain.
+"""Tests for the DOS/band reading fallback in FleurBandDosWorkChain.
 
 These tests cover the case where ``banddos.hdf`` is produced by an older
 FLEUR HDF5 schema whose ``/Local/DOS`` children (``INT``, ``MT:1s``,
 ``Sym``, ``Total``, ...) are not compatible with masci-tools' ``FleurDOS``
-recipe (which expects the newer multi-segment naming). The workchain
-must fall back to a direct h5py read instead of exiting with code 310.
+recipe (which expects the newer multi-segment naming), or whose HDF5 file
+lacks the attributes (``/kpts/specialPointLabels``) the
+``FleurSimpleBands`` recipe expects. The workchain must fall back to a
+direct h5py read instead of exiting with code 310.
 """
 from pathlib import Path
 
 import pytest
 
 from aiida.engine import ExitCode
-from aiida.orm import FolderData
+from aiida.orm import FolderData, KpointsData
 
-from aiida_fleur.workflows.banddos import _create_aiida_dos_data_impl as create_aiida_dos_data
+from aiida_fleur.workflows.banddos import (
+    _create_aiida_dos_data_impl as create_aiida_dos_data,
+    _create_aiida_bands_data_impl as create_aiida_bands_data,
+)
 
 
 BANDDOS_HDF5_PATH = Path(__file__).resolve().parents[2] / 'banddos.hdf'
@@ -46,8 +51,7 @@ def test_create_aiida_dos_data_legacy_schema(legacy_banddos_retrieved):
 
     result.store()
 
-    # x: (array, name, unit). aiida-core versions differ in attributes vs extras,
-    # so look in both to be safe.
+    # aiida-core versions differ in attributes vs extras, so look in both.
     attrs = {k: v for k, v in result.base.attributes.items()}
     extras = {k: v for k, v in result.base.extras.items()}
     x_arr = attrs.get('array|x_array') or extras.get('x_array')
@@ -63,7 +67,7 @@ def test_create_aiida_dos_data_legacy_schema(legacy_banddos_retrieved):
     assert y_units is not None and len(y_units) == len(y_names)
 
 
-def test_missing_banddos_returns_exit_300():
+def test_missing_banddos_dos_returns_exit_300():
     """When banddos.hdf is not retrieved, return ExitCode 300."""
     folder = FolderData()
     folder.put_object_from_bytes(b'not used', 'some_other.txt')
@@ -72,10 +76,67 @@ def test_missing_banddos_returns_exit_300():
     assert result.status == 300
 
 
-def test_corrupted_banddos_returns_exit_310():
+def test_corrupted_banddos_dos_returns_exit_310():
     """When banddos.hdf is unreadable, return ExitCode 310."""
     folder = FolderData()
     folder.put_object_from_bytes(b'this is not an HDF5 file', 'banddos.hdf')
     result = create_aiida_dos_data(retrieved=folder)
+    assert isinstance(result, ExitCode)
+    assert result.status == 310
+
+
+class _FakeFleurinp:
+    """Minimal stand-in for FleurinpData used only by create_aiida_bands_data.
+
+    The real FleurinpData.get_kpointsdata_ncf needs to parse inp.xml, which
+    requires a full FLEUR input. The fallback in create_aiida_bands_data only
+    uses kpoints for BandsData.set_kpointsdata, so we hand it a KpointsData
+    built from the same coordinates that are already inside banddos.hdf.
+    """
+
+    def get_kpointsdata_ncf(self, only_used=True):  # noqa: D401, ARG002
+        import h5py
+        with h5py.File(BANDDOS_HDF5_PATH, 'r') as f:
+            coords = f['/kpts/coordinates'][:]
+        kp = KpointsData()
+        kp.set_kpoints(coords)
+        return kp
+
+
+def test_create_aiida_bands_data_legacy_schema(legacy_banddos_retrieved):
+    """The legacy-schema fallback should produce a BandsData, not ExitCode 310."""
+    fleurinp = _FakeFleurinp()
+    result = create_aiida_bands_data(fleurinp=fleurinp, retrieved=legacy_banddos_retrieved)
+
+    assert not isinstance(result, ExitCode), (
+        f'create_aiida_bands_data returned {result!r}; expected BandsData')
+    assert result.label == 'output_banddos_wc_bands'
+
+    # BandsData has methods to inspect the kpoints/bands arrays.
+    result.store()
+    kp = result.base.attributes.get('array|kpoints')
+    bands = result.base.attributes.get('array|bands')
+    units = result.base.attributes.get('units')
+    assert kp is not None and len(kp) > 0
+    assert bands is not None and len(bands) > 0
+    assert units in ('eV', None)  # set_bands(units='eV')
+
+
+def test_missing_banddos_bands_returns_exit_300():
+    """When banddos.hdf is missing, return ExitCode 300."""
+    folder = FolderData()
+    folder.put_object_from_bytes(b'not used', 'some_other.txt')
+    fleurinp = _FakeFleurinp()
+    result = create_aiida_bands_data(fleurinp=fleurinp, retrieved=folder)
+    assert isinstance(result, ExitCode)
+    assert result.status == 300
+
+
+def test_corrupted_banddos_bands_returns_exit_310():
+    """When banddos.hdf is unreadable, return ExitCode 310."""
+    folder = FolderData()
+    folder.put_object_from_bytes(b'this is not an HDF5 file', 'banddos.hdf')
+    fleurinp = _FakeFleurinp()
+    result = create_aiida_bands_data(fleurinp=fleurinp, retrieved=folder)
     assert isinstance(result, ExitCode)
     assert result.status == 310

--- a/tests/workflows/test_banddos_hdf5_fallback.py
+++ b/tests/workflows/test_banddos_hdf5_fallback.py
@@ -22,6 +22,7 @@ from aiida_fleur.workflows.banddos import (
 
 
 BANDDOS_HDF5_PATH = Path(__file__).resolve().parents[2] / 'banddos.hdf'
+BANDDOS_BANDS_HDF5_PATH = Path(__file__).resolve().parents[2] / 'banddos_bands.hdf'
 
 
 def _make_retrieved_with_banddos(banddos_bytes):
@@ -39,6 +40,14 @@ def legacy_banddos_retrieved():
     if not BANDDOS_HDF5_PATH.exists():
         pytest.skip(f'Sample banddos.hdf not found at {BANDDOS_HDF5_PATH}')
     return _make_retrieved_with_banddos(BANDDOS_HDF5_PATH.read_bytes())
+
+
+@pytest.fixture
+def legacy_banddos_bands_retrieved():
+    """FolderData holding a band-mode banddos.hdf that uses /Local/BS/."""
+    if not BANDDOS_BANDS_HDF5_PATH.exists():
+        pytest.skip(f'Sample banddos_bands.hdf not found at {BANDDOS_BANDS_HDF5_PATH}')
+    return _make_retrieved_with_banddos(BANDDOS_BANDS_HDF5_PATH.read_bytes())
 
 
 def test_create_aiida_dos_data_legacy_schema(legacy_banddos_retrieved):
@@ -92,11 +101,16 @@ class _FakeFleurinp:
     requires a full FLEUR input. The fallback in create_aiida_bands_data only
     uses kpoints for BandsData.set_kpointsdata, so we hand it a KpointsData
     built from the same coordinates that are already inside banddos.hdf.
+
+    Set ``cls.hdf_path`` to point at a specific sample file if the default
+    one (DOS-mode ``banddos.hdf``) does not match the test data.
     """
+
+    hdf_path = BANDDOS_HDF5_PATH
 
     def get_kpointsdata_ncf(self, only_used=True):  # noqa: D401, ARG002
         import h5py
-        with h5py.File(BANDDOS_HDF5_PATH, 'r') as f:
+        with h5py.File(self.hdf_path, 'r') as f:
             coords = f['/kpts/coordinates'][:]
         kp = KpointsData()
         kp.set_kpoints(coords)
@@ -130,6 +144,25 @@ def test_missing_banddos_bands_returns_exit_300():
     result = create_aiida_bands_data(fleurinp=fleurinp, retrieved=folder)
     assert isinstance(result, ExitCode)
     assert result.status == 300
+
+
+def test_create_aiida_bands_data_local_bs_schema(legacy_banddos_bands_retrieved):
+    """A band-mode banddos.hdf that uses /Local/BS/ (older FLEUR) must also work.
+
+    The fallback looks up /Local/EV/eigenvalues first, then /Local/BS/eigenvalues.
+    This regression test guards against the second lookup going missing again.
+    """
+    fleurinp = _FakeFleurinp()
+    fleurinp.hdf_path = BANDDOS_BANDS_HDF5_PATH
+    result = create_aiida_bands_data(fleurinp=fleurinp, retrieved=legacy_banddos_bands_retrieved)
+    assert not isinstance(result, ExitCode), (
+        f'create_aiida_bands_data returned {result!r}; expected BandsData')
+    assert result.label == 'output_banddos_wc_bands'
+    result.store()
+    kp = result.base.attributes.get('array|kpoints')
+    bands = result.base.attributes.get('array|bands')
+    assert kp is not None and len(kp) > 0
+    assert bands is not None and len(bands) > 0
 
 
 def test_corrupted_banddos_bands_returns_exit_310():


### PR DESCRIPTION
### Summary

For **SOC** runs (`jspins=2`, `l_noco=T`) the masci-tools `FleurSimpleBands` / `FleurDOS` recipes fail on the 4-spin-channel `banddos.hdf` (`split_array ... Expected 4 Got: 2`), so aiida-fleur falls back to reading `/Local/BS/eigenvalues` and `/Local/DOS/*` directly. That fallback stored the **raw Hartree** values, mislabelled as eV:

* **bands**: raw Ha eigenvalues → now `(E - E_F) * HTR_TO_EV` with `E_F` from `/general lastFermiEnergy` (falls back to a pure unit conversion without shift when the attribute is missing), matching the recipe-path convention (energies relative to E_F in eV);
* **DOS**: energy grid in Ha (already `E - E_F`) → now `* HTR_TO_EV` in eV, DOS values `/ HTR_TO_EV` in 1/eV, units `'eV'` / `'1/eV'`.

Stacked on #216 (the legacy-schema fallback reading path this fix applies to).

### Tests

`tests/workflows/test_banddos_hdf5_fallback.py` (7 tests) pass against the sample `banddos.hdf` / `banddos_bands.hdf` fixtures — the DOS/Bands fallback now returns data with eV / 1/eV units. The Fermi-energy read coerces the h5py attribute to a plain float, avoiding the NumPy 1.25+ deprecation of `float()` on non-scalar arrays.